### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.16.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.0...oxc-browserslist-v0.16.1) - 2024-05-29
+
+### Other
+
+- Made everything slightly better

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "0.16.0"
+version     = "0.16.1"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 0.16.0 -> 0.16.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.0...oxc-browserslist-v0.16.1) - 2024-05-29

### Other
- *(deps)* lock file maintenance npm packages ([#17](https://github.com/oxc-project/oxc-browserslist/pull/17))
- rm .vscode
- codecov ignore generated files
- *(deps)* update pnpm/action-setup action to v4 ([#16](https://github.com/oxc-project/oxc-browserslist/pull/16))
- codecov ignore generated files
- *(README)* add badges
- add codecov ([#14](https://github.com/oxc-project/oxc-browserslist/pull/14))
- update README
- add release workflow
- improve queries::cover ([#12](https://github.com/oxc-project/oxc-browserslist/pull/12))
- use static vec instead of lazy cell ([#11](https://github.com/oxc-project/oxc-browserslist/pull/11))
- w
- clean up electron versions ([#10](https://github.com/oxc-project/oxc-browserslist/pull/10))
- use fxhash ([#9](https://github.com/oxc-project/oxc-browserslist/pull/9))
- remove string cache ([#8](https://github.com/oxc-project/oxc-browserslist/pull/8))
- add `cargo shear`
- update LICENSE
- use taiki-e/checkout-action
- *(deps)* lock file maintenance rust crates ([#7](https://github.com/oxc-project/oxc-browserslist/pull/7))
- enable more clippy rules
- clean up codegen
- add cargo check
- *(codegen)* preserve order of keys for all hashmaps
- fix typos
- format code
- commit `Cargo.lock`
- run `cargo codegen` before test
- remove submodules ([#5](https://github.com/oxc-project/oxc-browserslist/pull/5))
- add benchmark ([#4](https://github.com/oxc-project/oxc-browserslist/pull/4))
- add renovate bot
- refactor ([#3](https://github.com/oxc-project/oxc-browserslist/pull/3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).