### PR TITLE
chore: release v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.16.2](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.1...oxc-browserslist-v0.16.2) - 2024-05-30
 
-### Fixed
-- fix README badge
-
 ### Other
 - clean up node version and node releases ([#21](https://github.com/oxc-project/oxc-browserslist/pull/21))
-- *(examples)* remove `clap`
 - reduce the size of json data in "caniuse_feature_matching" ([#20](https://github.com/oxc-project/oxc-browserslist/pull/20))
 
 ## [0.16.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.0...oxc-browserslist-v0.16.1) - 2024-05-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.1...oxc-browserslist-v0.16.2) - 2024-05-30
+
+### Fixed
+- fix README badge
+
+### Other
+- clean up node version and node releases ([#21](https://github.com/oxc-project/oxc-browserslist/pull/21))
+- *(examples)* remove `clap`
+- reduce the size of json data in "caniuse_feature_matching" ([#20](https://github.com/oxc-project/oxc-browserslist/pull/20))
+
 ## [0.16.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.0...oxc-browserslist-v0.16.1) - 2024-05-29
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "chrono",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "0.16.1"
+version     = "0.16.2"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 0.16.1 -> 0.16.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.2](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.1...oxc-browserslist-v0.16.2) - 2024-05-30

### Fixed
- fix README badge

### Other
- clean up node version and node releases ([#21](https://github.com/oxc-project/oxc-browserslist/pull/21))
- *(examples)* remove `clap`
- reduce the size of json data in "caniuse_feature_matching" ([#20](https://github.com/oxc-project/oxc-browserslist/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).