### PR TITLE
feat!: change API to accept `&[S]` instead of `IntoIterator<Item = S>`

### DIFF
--- a/benches/resolve.rs
+++ b/benches/resolve.rs
@@ -5,37 +5,32 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("resolve 'defaults, not dead'", |b| {
         b.iter(|| {
             resolve(
-                black_box(vec!["defaults, not dead"]),
+                black_box(&["defaults, not dead"]),
                 &black_box(Opts::default()),
             )
         });
     });
 
     c.bench_function("resolve '> 0.5%'", |b| {
-        b.iter(|| resolve(black_box(vec!["> 0.5%"]), &black_box(Opts::default())));
+        b.iter(|| resolve(black_box(&["> 0.5%"]), &black_box(Opts::default())));
     });
 
     c.bench_function("resolve 'cover 99%'", |b| {
-        b.iter(|| resolve(black_box(vec!["cover 99%"]), &black_box(Opts::default())));
+        b.iter(|| resolve(black_box(&["cover 99%"]), &black_box(Opts::default())));
     });
 
     c.bench_function("resolve 'electron >= 10'", |b| {
-        b.iter(|| {
-            resolve(
-                black_box(vec!["electron >= 10"]),
-                &black_box(Opts::default()),
-            )
-        });
+        b.iter(|| resolve(black_box(&["electron >= 10"]), &black_box(Opts::default())));
     });
 
     c.bench_function("resolve 'node >= 8'", |b| {
-        b.iter(|| resolve(black_box(vec!["node >= 8"]), &black_box(Opts::default())));
+        b.iter(|| resolve(black_box(&["node >= 8"]), &black_box(Opts::default())));
     });
 
     c.bench_function("resolve 'supports es6-module'", |b| {
         b.iter(|| {
             resolve(
-                black_box(vec!["supports es6-module"]),
+                black_box(&["supports es6-module"]),
                 &black_box(Opts::default()),
             )
         });

--- a/examples/inspect.rs
+++ b/examples/inspect.rs
@@ -12,7 +12,7 @@ fn main() {
         .collect::<Vec<_>>();
 
     match resolve(
-        queries,
+        &queries,
         &Opts {
             mobile_to_desktop,
             ignore_unknown_versions,

--- a/src/queries/browserslist_config.rs
+++ b/src/queries/browserslist_config.rs
@@ -4,7 +4,7 @@ use crate::opts::Opts;
 pub(super) fn browserslist_config(opts: &Opts) -> QueryResult {
     #[cfg(target_arch = "wasm32")]
     {
-        crate::resolve(["defaults"], opts)
+        crate::resolve(&["defaults"], opts)
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/src/queries/dead.rs
+++ b/src/queries/dead.rs
@@ -3,7 +3,7 @@ use crate::{opts::Opts, resolve};
 
 pub(super) fn dead(opts: &Opts) -> QueryResult {
     resolve(
-        [
+        &[
             "Baidu >= 0",
             "ie <= 11",
             "ie_mob <= 11",

--- a/src/queries/defaults.rs
+++ b/src/queries/defaults.rs
@@ -3,7 +3,7 @@ use crate::{opts::Opts, resolve};
 
 pub(super) fn defaults(opts: &Opts) -> QueryResult {
     resolve(
-        ["> 0.5%", "last 2 versions", "Firefox ESR", "not dead"],
+        &["> 0.5%", "last 2 versions", "Firefox ESR", "not dead"],
         opts,
     )
 }

--- a/src/queries/extends.rs
+++ b/src/queries/extends.rs
@@ -36,7 +36,7 @@ pub(super) fn extends(pkg: &str, opts: &Opts) -> QueryResult {
     let config = serde_json::from_str(&String::from_utf8_lossy(&output))
         .map_err(|_| Error::FailedToResolveExtend(pkg.to_string()))?;
 
-    resolve(config::load_with_config(config, opts)?, opts)
+    resolve(&config::load_with_config(config, opts)?, opts)
 }
 
 fn check_extend_name(pkg: &str) -> Result<(), Error> {

--- a/src/queries/mod.rs
+++ b/src/queries/mod.rs
@@ -54,7 +54,7 @@ mod years;
 /// ```
 /// use browserslist::{Opts, resolve};
 ///
-/// let distrib = &resolve(["firefox 93"], &Opts::default()).unwrap()[0];
+/// let distrib = &resolve(&["firefox 93"], &Opts::default()).unwrap()[0];
 ///
 /// assert_eq!(distrib.name(), "firefox");
 /// assert_eq!(distrib.version(), "93");
@@ -73,7 +73,7 @@ impl Distrib {
     /// ```
     /// use browserslist::{Opts, resolve};
     ///
-    /// let distrib = &resolve(["firefox 93"], &Opts::default()).unwrap()[0];
+    /// let distrib = &resolve(&["firefox 93"], &Opts::default()).unwrap()[0];
     ///
     /// assert_eq!(distrib.name(), "firefox");
     /// ```
@@ -88,7 +88,7 @@ impl Distrib {
     /// ```
     /// use browserslist::{Opts, resolve};
     ///
-    /// let distrib = &resolve(["firefox 93"], &Opts::default()).unwrap()[0];
+    /// let distrib = &resolve(&["firefox 93"], &Opts::default()).unwrap()[0];
     ///
     /// assert_eq!(distrib.version(), "93");
     /// ```

--- a/src/test.rs
+++ b/src/test.rs
@@ -30,7 +30,7 @@ pub fn run_compare(query: &str, opts: &Opts, cwd: Option<&Path>) {
         .filter(|line| !line.is_empty())
         .collect::<Vec<_>>();
 
-    let actual = resolve([query], opts)
+    let actual = resolve(&[query], opts)
         .unwrap()
         .iter()
         .map(std::string::ToString::to_string)
@@ -40,5 +40,5 @@ pub fn run_compare(query: &str, opts: &Opts, cwd: Option<&Path>) {
 }
 
 pub fn should_failed(query: &str, opts: &Opts) -> Error {
-    resolve([query], opts).unwrap_err()
+    resolve(&[query], opts).unwrap_err()
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,7 +7,7 @@ pub fn browserslist(query: String, opts: JsValue) -> Result<JsValue, JsValue> {
     let opts: Option<Opts> = serde_wasm_bindgen::from_value(opts)?;
 
     serde_wasm_bindgen::to_value(
-        &resolve([query], &opts.unwrap_or_default())
+        &resolve(&[query], &opts.unwrap_or_default())
             .map_err(|e| format!("{}", e))?
             .into_iter()
             .map(|d| d.to_string())


### PR DESCRIPTION
This reduces 1 allocation for the common case where the input is a single item `&[s]`