### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.2...oxc-browserslist-v0.17.0) - 2024-06-01
+
+### Added
+- [**breaking**] change `Error::Nom` to `Error::parse` for future compatibility ([#39](https://github.com/oxc-project/oxc-browserslist/pull/39))
+- [**breaking**] change API to accept `&[S]` instead of `IntoIterator<Item = S>` ([#29](https://github.com/oxc-project/oxc-browserslist/pull/29))
+
+### Other
+- update README
+- remove `#![allow(missing_docs, dead_code, clippy::pedantic)]` from generated/
+- update README
+- update README
+- bump `electron-to-chromium`
+- clean up some formatting
+- update docs
+- check doc
+- add cargo fmt
+- add typos
+- update README
+- benchmark build the main crate only ([#35](https://github.com/oxc-project/oxc-browserslist/pull/35))
+- remove some generic code
+- clean up some cold
+- format code `use_small_heuristics = "Max"`
+- *(xtask)* clean up some code
+- remove `once_cell` ([#33](https://github.com/oxc-project/oxc-browserslist/pull/33))
+- shrink generated code size ([#32](https://github.com/oxc-project/oxc-browserslist/pull/32))
+- remove `once_cell` from CANIUSE_BROWSERS ([#30](https://github.com/oxc-project/oxc-browserslist/pull/30))
+- remove `crate-type` from Cargo.toml
+- improve sort method ([#28](https://github.com/oxc-project/oxc-browserslist/pull/28))
+- remove itertools ([#27](https://github.com/oxc-project/oxc-browserslist/pull/27))
+- remove `either` ([#26](https://github.com/oxc-project/oxc-browserslist/pull/26))
+- remove `chrono` ([#24](https://github.com/oxc-project/oxc-browserslist/pull/24))
+
 ## [0.16.2](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.1...oxc-browserslist-v0.16.2) - 2024-05-30
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,28 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [**breaking**] change API to accept `&[S]` instead of `IntoIterator<Item = S>` ([#29](https://github.com/oxc-project/oxc-browserslist/pull/29))
 
 ### Other
-- update README
-- remove `#![allow(missing_docs, dead_code, clippy::pedantic)]` from generated/
-- update README
-- update README
 - bump `electron-to-chromium`
-- clean up some formatting
-- update docs
-- check doc
-- add cargo fmt
-- add typos
-- update README
-- benchmark build the main crate only ([#35](https://github.com/oxc-project/oxc-browserslist/pull/35))
-- remove some generic code
-- clean up some cold
-- format code `use_small_heuristics = "Max"`
-- *(xtask)* clean up some code
 - remove `once_cell` ([#33](https://github.com/oxc-project/oxc-browserslist/pull/33))
 - shrink generated code size ([#32](https://github.com/oxc-project/oxc-browserslist/pull/32))
 - remove `once_cell` from CANIUSE_BROWSERS ([#30](https://github.com/oxc-project/oxc-browserslist/pull/30))
 - remove `crate-type` from Cargo.toml
 - improve sort method ([#28](https://github.com/oxc-project/oxc-browserslist/pull/28))
-- remove itertools ([#27](https://github.com/oxc-project/oxc-browserslist/pull/27))
+- remove `itertools` ([#27](https://github.com/oxc-project/oxc-browserslist/pull/27))
 - remove `either` ([#26](https://github.com/oxc-project/oxc-browserslist/pull/26))
 - remove `chrono` ([#24](https://github.com/oxc-project/oxc-browserslist/pull/24))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "criterion2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "0.16.2"
+version     = "0.17.0"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 0.16.2 -> 0.17.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.2...oxc-browserslist-v0.17.0) - 2024-06-01

### Added
- [**breaking**] change `Error::Nom` to `Error::parse` for future compatibility ([#39](https://github.com/oxc-project/oxc-browserslist/pull/39))
- [**breaking**] change API to accept `&[S]` instead of `IntoIterator<Item = S>` ([#29](https://github.com/oxc-project/oxc-browserslist/pull/29))

### Other
- update README
- remove `#![allow(missing_docs, dead_code, clippy::pedantic)]` from generated/
- update README
- update README
- bump `electron-to-chromium`
- clean up some formatting
- update docs
- check doc
- add cargo fmt
- add typos
- update README
- benchmark build the main crate only ([#35](https://github.com/oxc-project/oxc-browserslist/pull/35))
- remove some generic code
- clean up some cold
- format code `use_small_heuristics = "Max"`
- *(xtask)* clean up some code
- remove `once_cell` ([#33](https://github.com/oxc-project/oxc-browserslist/pull/33))
- shrink generated code size ([#32](https://github.com/oxc-project/oxc-browserslist/pull/32))
- remove `once_cell` from CANIUSE_BROWSERS ([#30](https://github.com/oxc-project/oxc-browserslist/pull/30))
- remove `crate-type` from Cargo.toml
- improve sort method ([#28](https://github.com/oxc-project/oxc-browserslist/pull/28))
- remove itertools ([#27](https://github.com/oxc-project/oxc-browserslist/pull/27))
- remove `either` ([#26](https://github.com/oxc-project/oxc-browserslist/pull/26))
- remove `chrono` ([#24](https://github.com/oxc-project/oxc-browserslist/pull/24))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).