### PR TITLE
chore: prepare release 0.18.0

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,29 @@
+name: Prepare Release PR
+
+on:
+  push:
+    branches:
+      - knope.toml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name GitHub Actions
+          git config user.email github-actions@github.com
+
+      - uses: knope-dev/action@v2.1.0
+
+      - run: knope prepare-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - Made everything slightly better
+## 0.18.0 (2024-06-02)
+
+### Breaking Changes
+
+- change API to accept `&[S]` instead of `IntoIterator<Item = S>` (#29)
+- change `Error::Nom` to `Error::parse` for future compatibility (#39)
+
+### Features
+
+- use codegen instead of build.rs (#2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "0.17.0"
+version     = "0.18.0"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."

--- a/knope.toml
+++ b/knope.toml
@@ -1,0 +1,41 @@
+[github]
+owner = "oxc-project"
+repo  = "oxc-browserslist"
+
+[package]
+name = "oxc-browserslist"
+versioned_files = ["Cargo.toml"]
+changelog = "CHANGELOG.md"
+
+[[workflows]]
+name = "prepare-release"
+
+[[workflows.steps]]
+type = "Command"
+command = "git switch -c release"
+
+[[workflows.steps]]
+type = "PrepareRelease"
+
+[[workflows.steps]]
+type = "Command"
+command = "git commit -m \"chore: prepare release $version\""
+
+[[workflows.steps]]
+type = "Command"
+command = "git push --force --set-upstream origin release"
+
+[workflows.steps.variables]
+"$version" = "Version"
+
+[[workflows.steps]]
+type = "CreatePullRequest"
+base = "main"
+
+[workflows.steps.title]
+template = "chore: prepare release $version"
+variables = { "$version" = "Version" }
+
+[workflows.steps.body]
+template = "This PR was created by Knope. Merging it will create a new release\n\n$changelog"
+variables = { "$changelog" = "ChangelogEntry" }


### PR DESCRIPTION
This PR was created by Knope. Merging it will create a new release

### Breaking Changes

- change API to accept `&[S]` instead of `IntoIterator<Item = S>` (#29)
- change `Error::Nom` to `Error::parse` for future compatibility (#39)

### Features

- use codegen instead of build.rs (#2)