### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.17.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.17.0...oxc-browserslist-v0.17.1) - 2024-06-17
 
 ### Other
-- bump npm packages at anytime
 - *(deps)* update npm packages ([#45](https://github.com/oxc-project/oxc-browserslist/pull/45))
-- install pnpm with the correct versions ([#47](https://github.com/oxc-project/oxc-browserslist/pull/47))
-- *(deps)* update rust crate criterion2 to 0.11.0
-- *(deps)* update dependency rust to v1.79.0 ([#44](https://github.com/oxc-project/oxc-browserslist/pull/44))
-- Update README.md
-- *(deps)* lock file maintenance rust crates
-- *(deps)* lock file maintenance npm packages
-- release ignore markdown and yml files
-- update README
-- *(xtask)* split up code
-- update README
-- update README
 
 ## [0.17.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.2...oxc-browserslist-v0.17.0) - 2024-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.17.0...oxc-browserslist-v0.17.1) - 2024-06-17
+
+### Other
+- bump npm packages at anytime
+- *(deps)* update npm packages ([#45](https://github.com/oxc-project/oxc-browserslist/pull/45))
+- install pnpm with the correct versions ([#47](https://github.com/oxc-project/oxc-browserslist/pull/47))
+- *(deps)* update rust crate criterion2 to 0.11.0
+- *(deps)* update dependency rust to v1.79.0 ([#44](https://github.com/oxc-project/oxc-browserslist/pull/44))
+- Update README.md
+- *(deps)* lock file maintenance rust crates
+- *(deps)* lock file maintenance npm packages
+- release ignore markdown and yml files
+- update README
+- *(xtask)* split up code
+- update README
+- update README
+
 ## [0.17.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.16.2...oxc-browserslist-v0.17.0) - 2024-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "criterion2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "0.17.0"
+version     = "0.17.1"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 0.17.0 -> 0.17.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.17.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v0.17.0...oxc-browserslist-v0.17.1) - 2024-06-17

### Other
- bump npm packages at anytime
- *(deps)* update npm packages ([#45](https://github.com/oxc-project/oxc-browserslist/pull/45))
- install pnpm with the correct versions ([#47](https://github.com/oxc-project/oxc-browserslist/pull/47))
- *(deps)* update rust crate criterion2 to 0.11.0
- *(deps)* update dependency rust to v1.79.0 ([#44](https://github.com/oxc-project/oxc-browserslist/pull/44))
- Update README.md
- *(deps)* lock file maintenance rust crates
- *(deps)* lock file maintenance npm packages
- release ignore markdown and yml files
- update README
- *(xtask)* split up code
- update README
- update README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).