### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.2...oxc-browserslist-v1.0.3) - 2024-08-20
+
+### Fixed
+- downgrade caniuse-db to `1.0.30001639`
+
+### Other
+- sort caniuse_region_matching data
+- install rustfmt in test for `cargo codegen`
+- ??
+- try peerDependencies
+- `git diff --exit-code --quiet`
+- test change of generated files; run `cargo codegen` after lock file change
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crate criterion2 to v1
+- *(deps)* update dependency rust to v1.80.0 ([#59](https://github.com/oxc-project/oxc-browserslist/pull/59))
+
 ## [1.0.2](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.1...oxc-browserslist-v1.0.2) - 2024-07-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "criterion2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "1.0.2"
+version     = "1.0.3"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 1.0.2 -> 1.0.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.3](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.2...oxc-browserslist-v1.0.3) - 2024-08-20

### Fixed
- downgrade caniuse-db to `1.0.30001639`

### Other
- sort caniuse_region_matching data
- install rustfmt in test for `cargo codegen`
- ??
- try peerDependencies
- `git diff --exit-code --quiet`
- test change of generated files; run `cargo codegen` after lock file change
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crate criterion2 to v1
- *(deps)* update dependency rust to v1.80.0 ([#59](https://github.com/oxc-project/oxc-browserslist/pull/59))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).