### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.3...oxc-browserslist-v1.1.0) - 2024-10-30
+
+### Added
+
+- export `Version` ([#74](https://github.com/oxc-project/oxc-browserslist/pull/74))
+
+### Other
+
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update rust crate indexmap to v2.6.0
+- *(deps)* update rust crates
+- *(deps)* update rust crates
+- *(deps)* update dependency rust to v1.81.0 ([#70](https://github.com/oxc-project/oxc-browserslist/pull/70))
+
 ## [1.0.3](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.2...oxc-browserslist-v1.0.3) - 2024-09-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "oxc-browserslist"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "criterion2",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "oxc-browserslist"
-version     = "1.0.3"
+version     = "1.1.0"
 authors     = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 edition     = "2021"
 description = "Rust-ported Browserslist for Oxc."


### PR DESCRIPTION
## 🤖 New release
* `oxc-browserslist`: 1.0.3 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v1.0.3...oxc-browserslist-v1.1.0) - 2024-10-30

### Added

- export `Version` ([#74](https://github.com/oxc-project/oxc-browserslist/pull/74))

### Other

- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update rust crate indexmap to v2.6.0
- *(deps)* update rust crates
- *(deps)* update rust crates
- *(deps)* update dependency rust to v1.81.0 ([#70](https://github.com/oxc-project/oxc-browserslist/pull/70))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).