### PR TITLE
chore: release v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.0...oxc-browserslist-v2.1.1) - 2025-09-20
+
+### Other
+
+- *(deps)* browserslist v4.26.2
+- add Miri workflow for memory safety testing ([#301](https://github.com/oxc-project/oxc-browserslist/pull/301))
+- remove all Box::leak usage using Cow
+- replace Box::leak with Cow for version strings
+
 ## [2.1.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.0.16...oxc-browserslist-v2.1.0) - 2025-09-18
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxc-browserslist"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "bincode 2.0.1",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-browserslist"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 categories = ["config", "web-programming"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc-browserslist`: 2.1.0 -> 2.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.1](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.0...oxc-browserslist-v2.1.1) - 2025-09-20

### Other

- *(deps)* browserslist v4.26.2
- add Miri workflow for memory safety testing ([#301](https://github.com/oxc-project/oxc-browserslist/pull/301))
- remove all Box::leak usage using Cow
- replace Box::leak with Cow for version strings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).