### PR TITLE
perf: Remove unnecessary string allocations in query functions

### DIFF
--- a/src/queries/browser_bounded_range.rs
+++ b/src/queries/browser_bounded_range.rs
@@ -26,7 +26,7 @@ pub(super) fn browser_bounded_range(name: &str, from: &str, to: &str, opts: &Opt
             let version = version.parse().unwrap_or_default();
             from <= version && version <= to
         })
-        .map(|version| Distrib::new(name, version.to_string()))
+        .map(|version| Distrib::new(name, version))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/browser_unbounded_range.rs
+++ b/src/queries/browser_unbounded_range.rs
@@ -36,7 +36,7 @@ pub(super) fn browser_unbounded_range(
                 Comparator::LessOrEqual => v <= version,
             }
         })
-        .map(|version| Distrib::new(name, version.to_string()))
+        .map(|version| Distrib::new(name, version))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/cover.rs
+++ b/src/queries/cover.rs
@@ -8,7 +8,7 @@ pub(super) fn cover(coverage: f32) -> QueryResult {
         if total >= coverage || *usage == 0.0 {
             break;
         }
-        distribs.push(Distrib::new(decode_browser_name(*name), version.to_string()));
+        distribs.push(Distrib::new(decode_browser_name(*name), *version));
         total += usage;
     }
     Ok(distribs)

--- a/src/queries/cover_by_region.rs
+++ b/src/queries/cover_by_region.rs
@@ -14,7 +14,7 @@ pub(super) fn cover_by_region(coverage: f32, region: &str) -> QueryResult {
                 if total >= coverage || usage == 0.0 {
                     ControlFlow::Break((distribs, total))
                 } else {
-                    distribs.push(Distrib::new(name.to_string(), version.to_string()));
+                    distribs.push(Distrib::new(name, version));
                     ControlFlow::Continue((distribs, total + usage))
                 }
             },

--- a/src/queries/last_n_x_browsers.rs
+++ b/src/queries/last_n_x_browsers.rs
@@ -12,7 +12,7 @@ pub(super) fn last_n_x_browsers(count: usize, name: &str, opts: &Opts) -> QueryR
         .filter(|version| version.release_date().is_some())
         .rev()
         .take(count)
-        .map(|version| Distrib::new(name, version.version().to_string()))
+        .map(|version| Distrib::new(name, version.version()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/percentage.rs
+++ b/src/queries/percentage.rs
@@ -16,7 +16,7 @@ pub(super) fn percentage(comparator: Comparator, popularity: f32) -> QueryResult
                         Comparator::LessOrEqual => usage <= popularity,
                     }
                 })
-                .map(move |version| Distrib::new(name.as_ref(), version.version().to_string()))
+                .map(move |version| Distrib::new(name.as_ref(), version.version()))
         })
         .collect();
     Ok(distribs)

--- a/src/queries/percentage_by_region.rs
+++ b/src/queries/percentage_by_region.rs
@@ -18,7 +18,7 @@ pub(super) fn percentage_by_region(
                 Comparator::GreaterOrEqual => *usage >= popularity,
                 Comparator::LessOrEqual => *usage <= popularity,
             })
-            .map(|(name, version, _)| Distrib::new(name.to_string(), version.to_string()))
+            .map(|(name, version, _)| Distrib::new(name, version))
             .collect();
         Ok(distribs)
     } else {

--- a/src/queries/since.rs
+++ b/src/queries/since.rs
@@ -23,7 +23,7 @@ pub(super) fn since(year: i32, month: u32, day: u32, opts: &Opts) -> QueryResult
                 .filter(
                     |version| matches!(version.release_date(), Some(date) if date.get() >= time),
                 )
-                .map(move |version| Distrib::new(name, version.version().to_string()))
+                .map(move |version| Distrib::new(name, version.version()))
         })
         .collect();
     Ok(distribs)

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -57,7 +57,7 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                         }
                         None
                     })
-                    .map(move |version| Distrib::new(name, version.to_string()))
+                    .map(move |version| Distrib::new(name, version))
             })
             .collect();
         Ok(distribs)

--- a/src/queries/unreleased_browsers.rs
+++ b/src/queries/unreleased_browsers.rs
@@ -12,7 +12,7 @@ pub(super) fn unreleased_browsers(opts: &Opts) -> QueryResult {
             stat.version_list
                 .iter()
                 .filter(|version| version.release_date().is_none())
-                .map(move |version| Distrib::new(name, version.version().to_string()))
+                .map(move |version| Distrib::new(name, version.version()))
         })
         .collect();
     Ok(distribs)

--- a/src/queries/unreleased_x_browsers.rs
+++ b/src/queries/unreleased_x_browsers.rs
@@ -8,7 +8,7 @@ pub(super) fn unreleased_x_browsers(name: &str, opts: &Opts) -> QueryResult {
         .version_list
         .iter()
         .filter(|version| version.release_date().is_none())
-        .map(|version| Distrib::new(name, version.version().to_string()))
+        .map(|version| Distrib::new(name, version.version()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/years.rs
+++ b/src/queries/years.rs
@@ -23,7 +23,7 @@ pub(super) fn years(count: f64, opts: &Opts) -> QueryResult {
                 .filter(
                     |version| matches!(version.release_date(), Some(date) if date.get() >= time),
                 )
-                .map(move |version| Distrib::new(name, version.version().to_string()))
+                .map(move |version| Distrib::new(name, version.version()))
         })
         .collect();
     Ok(distribs)


### PR DESCRIPTION
## Summary
Removes `.to_string()` calls when creating `Distrib` objects in query functions. Since `Distrib::new` accepts `Into<Cow<'static, str>>`, it can work with borrowed `&str` directly instead of requiring owned `String`s.

## Changes
This eliminates allocations in hot paths across 12 query functions:
- `percentage`, `percentage_by_region`
- `since`, `years`
- `unreleased_browsers`, `unreleased_x_browsers`
- `last_n_x_browsers`
- `browser_bounded_range`, `browser_unbounded_range`
- `supports`
- `cover`, `cover_by_region`

## Impact
- **Performance**: Reduces memory allocations in frequently-called query functions
- **Code quality**: More idiomatic Rust usage of `Cow<'static, str>`
- **Binary size**: No change

## Test plan
- [x] Code compiles successfully
- [x] Verified test status unchanged (existing test failures are unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)