### PR TITLE
chore: release v2.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.4](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.3...oxc-browserslist-v2.1.4) - 2025-12-10
+
+### Other
+
+- Update browserslist from 4.28.1 to 4.28.1 ([#420](https://github.com/oxc-project/oxc-browserslist/pull/420))
+- Update browserslist from 4.28.0 to 4.28.0 ([#412](https://github.com/oxc-project/oxc-browserslist/pull/412))
+- *(deps)* update rust crates ([#409](https://github.com/oxc-project/oxc-browserslist/pull/409))
+- Update browserslist from 4.28.0 to 4.28.0 ([#404](https://github.com/oxc-project/oxc-browserslist/pull/404))
+- *(deps)* update rust crates to v2.12.1 ([#400](https://github.com/oxc-project/oxc-browserslist/pull/400))
+- Update browserslist from 4.28.0 to 4.28.0 ([#397](https://github.com/oxc-project/oxc-browserslist/pull/397))
+- Update browserslist from 4.28.0 to 4.28.0 ([#394](https://github.com/oxc-project/oxc-browserslist/pull/394))
+- *(deps)* update rust crate syn to v2.0.110 ([#392](https://github.com/oxc-project/oxc-browserslist/pull/392))
+- Update browserslist from 4.27.0 to 4.27.0 ([#388](https://github.com/oxc-project/oxc-browserslist/pull/388))
+
 ## [2.1.3](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.2...oxc-browserslist-v2.1.3) - 2025-11-10
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxc-browserslist"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "bincode 2.0.1",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-browserslist"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 categories = ["config", "web-programming"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc-browserslist`: 2.1.3 -> 2.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.1.4](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.3...oxc-browserslist-v2.1.4) - 2025-12-10

### Other

- Update browserslist from 4.28.1 to 4.28.1 ([#420](https://github.com/oxc-project/oxc-browserslist/pull/420))
- Update browserslist from 4.28.0 to 4.28.0 ([#412](https://github.com/oxc-project/oxc-browserslist/pull/412))
- *(deps)* update rust crates ([#409](https://github.com/oxc-project/oxc-browserslist/pull/409))
- Update browserslist from 4.28.0 to 4.28.0 ([#404](https://github.com/oxc-project/oxc-browserslist/pull/404))
- *(deps)* update rust crates to v2.12.1 ([#400](https://github.com/oxc-project/oxc-browserslist/pull/400))
- Update browserslist from 4.28.0 to 4.28.0 ([#397](https://github.com/oxc-project/oxc-browserslist/pull/397))
- Update browserslist from 4.28.0 to 4.28.0 ([#394](https://github.com/oxc-project/oxc-browserslist/pull/394))
- *(deps)* update rust crate syn to v2.0.110 ([#392](https://github.com/oxc-project/oxc-browserslist/pull/392))
- Update browserslist from 4.27.0 to 4.27.0 ([#388](https://github.com/oxc-project/oxc-browserslist/pull/388))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).