### PR TITLE
chore: release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.5...oxc-browserslist-v2.2.0) - 2026-01-09
+
+### Added
+
+- replace bincode to postcard ([#457](https://github.com/oxc-project/oxc-browserslist/pull/457))
+
+### Other
+
+- Update browserslist from 4.28.1 to 4.28.1 ([#458](https://github.com/oxc-project/oxc-browserslist/pull/458))
+- *(deps)* update rust crate syn to v2.0.113 ([#450](https://github.com/oxc-project/oxc-browserslist/pull/450))
+- *(deps)* update dependency oxfmt to ^0.21.0 ([#444](https://github.com/oxc-project/oxc-browserslist/pull/444))
+
 ## [2.1.5](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.4...oxc-browserslist-v2.1.5) - 2025-12-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "oxc-browserslist"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "criterion2",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-browserslist"
-version = "2.1.5"
+version = "2.2.0"
 authors = ["Boshen <boshenc@gmail.com>", "Pig Fang <g-plane@hotmail.com>"]
 categories = ["config", "web-programming"]
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `oxc-browserslist`: 2.1.5 -> 2.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.2.0](https://github.com/oxc-project/oxc-browserslist/compare/oxc-browserslist-v2.1.5...oxc-browserslist-v2.2.0) - 2026-01-09

### Added

- replace bincode to postcard ([#457](https://github.com/oxc-project/oxc-browserslist/pull/457))

### Other

- Update browserslist from 4.28.1 to 4.28.1 ([#458](https://github.com/oxc-project/oxc-browserslist/pull/458))
- *(deps)* update rust crate syn to v2.0.113 ([#450](https://github.com/oxc-project/oxc-browserslist/pull/450))
- *(deps)* update dependency oxfmt to ^0.21.0 ([#444](https://github.com/oxc-project/oxc-browserslist/pull/444))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).