### PR TITLE
Consolidate bundled-data loading behind compression helpers

### DIFF
--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -45,10 +45,9 @@ pub use crate::generated::caniuse_global_usage::{CANIUSE_GLOBAL_USAGE, GLOBAL_US
 pub fn caniuse_browsers() -> &'static CaniuseData {
     static CANIUSE_BROWSERS: OnceLock<CaniuseData> = OnceLock::new();
     CANIUSE_BROWSERS.get_or_init(|| {
-        const COMPRESSED: &[u8] = include_bytes!("../generated/caniuse_browsers.bin.deflate");
-        let decompressed = compression::decompress_deflate(COMPRESSED);
         type BrowserData = Vec<(String, String, Vec<(String, f32, Option<i64>)>)>;
-        let data: BrowserData = postcard::from_bytes(&decompressed).unwrap();
+        let data: BrowserData =
+            compression::load(include_bytes!("../generated/caniuse_browsers.bin.deflate"));
         data.into_iter()
             .map(|(_key, name, version_list)| {
                 let name_cow = Cow::Owned(name.clone());

--- a/src/data/caniuse/compression.rs
+++ b/src/data/caniuse/compression.rs
@@ -1,5 +1,8 @@
-use flate2::read::DeflateDecoder;
 use std::io::Read;
+use std::sync::OnceLock;
+
+use flate2::read::DeflateDecoder;
+use serde::de::DeserializeOwned;
 
 /// Decompress deflate-compressed data.
 pub fn decompress_deflate(compressed_data: &[u8]) -> Vec<u8> {
@@ -7,4 +10,46 @@ pub fn decompress_deflate(compressed_data: &[u8]) -> Vec<u8> {
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).expect("Failed to decompress data");
     decompressed
+}
+
+/// Decompress a bundled blob and postcard-deserialize it in one step. Used directly by the few
+/// call sites that transform the decoded value further (and reused by [`LazyData`]).
+pub fn load<T: DeserializeOwned>(compressed: &[u8]) -> T {
+    postcard::from_bytes(&decompress_deflate(compressed)).unwrap()
+}
+
+/// A bundled blob that is decompressed and postcard-deserialized into `T` on first access, then
+/// cached for the rest of the process. Use this when the deserialized value is consumed as-is; use
+/// [`LazyBlob`] when the bytes are decoded by hand at the use site.
+pub struct LazyData<T> {
+    compressed: &'static [u8],
+    cell: OnceLock<T>,
+}
+
+impl<T: DeserializeOwned> LazyData<T> {
+    pub const fn new(compressed: &'static [u8]) -> Self {
+        Self { compressed, cell: OnceLock::new() }
+    }
+
+    pub fn get(&self) -> &T {
+        self.cell.get_or_init(|| load(self.compressed))
+    }
+}
+
+/// A bundled blob that is decompressed to raw bytes on first access, then cached. Use this for data
+/// decoded by hand at the use site (the byte-plane and run-length blobs), where a generic
+/// deserializer would bloat the binary.
+pub struct LazyBlob {
+    compressed: &'static [u8],
+    cell: OnceLock<Vec<u8>>,
+}
+
+impl LazyBlob {
+    pub const fn new(compressed: &'static [u8]) -> Self {
+        Self { compressed, cell: OnceLock::new() }
+    }
+
+    pub fn get(&self) -> &[u8] {
+        self.cell.get_or_init(|| decompress_deflate(self.compressed))
+    }
 }

--- a/src/data/caniuse/features.rs
+++ b/src/data/caniuse/features.rs
@@ -1,33 +1,19 @@
-use std::sync::OnceLock;
-
-use super::{BrowserName, compression::decompress_deflate};
+use super::{
+    BrowserName,
+    compression::{LazyBlob, LazyData},
+};
 
 use crate::data::decode_browser_name;
 pub use crate::generated::caniuse_feature_matching::get_feature_stat;
 
-static FEATURES: OnceLock<Vec<u8>> = OnceLock::new();
-static VERSION_TABLE: OnceLock<Vec<String>> = OnceLock::new();
+static FEATURES: LazyBlob =
+    LazyBlob::new(include_bytes!("../../generated/caniuse_feature_matching.bin.deflate"));
+static VERSION_TABLE: LazyData<Vec<String>> =
+    LazyData::new(include_bytes!("../../generated/caniuse_feature_version_table.bin.deflate"));
 /// Per-browser version order (browser id -> version-table indices, in version order). Feature
 /// support lists are stored as runs of local indices into this order; see `create_data`.
-static BROWSER_VERSIONS: OnceLock<Vec<Vec<u16>>> = OnceLock::new();
-
-fn version_table() -> &'static [String] {
-    VERSION_TABLE.get_or_init(|| {
-        postcard::from_bytes(&decompress_deflate(include_bytes!(
-            "../../generated/caniuse_feature_version_table.bin.deflate"
-        )))
-        .unwrap()
-    })
-}
-
-fn browser_versions() -> &'static [Vec<u16>] {
-    BROWSER_VERSIONS.get_or_init(|| {
-        postcard::from_bytes(&decompress_deflate(include_bytes!(
-            "../../generated/caniuse_feature_browser_versions.bin.deflate"
-        )))
-        .unwrap()
-    })
-}
+static BROWSER_VERSIONS: LazyData<Vec<Vec<u16>>> =
+    LazyData::new(include_bytes!("../../generated/caniuse_feature_browser_versions.bin.deflate"));
 
 pub struct FeatureSet {
     yes: Vec</* version */ &'static str>,
@@ -56,20 +42,15 @@ impl Feature {
     }
 
     pub fn create_data(&self) -> Vec<(BrowserName, FeatureSet)> {
-        let features_data = FEATURES.get_or_init(|| {
-            decompress_deflate(include_bytes!(
-                "../../generated/caniuse_feature_matching.bin.deflate"
-            ))
-        });
-        let table = version_table();
-        let browser_versions = browser_versions();
+        let table: &'static [String] = VERSION_TABLE.get();
+        let browser_versions = BROWSER_VERSIONS.get();
         // The slice is hand-decoded rather than handed to `postcard::from_bytes`: a generic
         // deserializer for this nested type monomorphizes into several KB of code that would dwarf
         // the data it saves. The layout (postcard-compatible) is, per browser entry: one browser
         // byte, then the `yes` list, then the `partial` list. Each list is a varint run count
         // followed by `(start, length)` varint runs of local indices into the browser's version
         // order.
-        let bytes = &features_data[self.start as usize..self.end as usize];
+        let bytes = &FEATURES.get()[self.start as usize..self.end as usize];
         let mut pos = 0;
         let entry_count = read_varint(bytes, &mut pos);
         let mut data = Vec::with_capacity(entry_count);

--- a/src/data/caniuse/region.rs
+++ b/src/data/caniuse/region.rs
@@ -1,12 +1,17 @@
 use std::sync::OnceLock;
 
-use super::{BrowserName, compression::decompress_deflate};
+use super::{
+    BrowserName,
+    compression::{LazyBlob, load},
+};
 
 use crate::data::decode_browser_name;
 pub use crate::generated::caniuse_region_matching::get_usage_by_region;
 
-static PAIR_INDICES: OnceLock<Vec<u8>> = OnceLock::new();
-static PERCENTAGES: OnceLock<Vec<u8>> = OnceLock::new();
+static PAIR_INDICES: LazyBlob =
+    LazyBlob::new(include_bytes!("../../generated/caniuse_region_pair_indices.bin.deflate"));
+static PERCENTAGES: LazyBlob =
+    LazyBlob::new(include_bytes!("../../generated/caniuse_region_percentages.bin.deflate"));
 /// Global (browser, version) intern table shared by every region: the browser id and resolved
 /// version string at each pair index.
 static PAIR_TABLE: OnceLock<(Vec<u8>, Vec<String>)> = OnceLock::new();
@@ -20,14 +25,10 @@ pub struct RegionData {
 
 fn pair_table() -> &'static (Vec<u8>, Vec<String>) {
     PAIR_TABLE.get_or_init(|| {
-        let pairs =
-            decompress_deflate(include_bytes!("../../generated/caniuse_region_pairs.bin.deflate"));
         let (browsers, version_indices): (Vec<u8>, Vec<u16>) =
-            postcard::from_bytes(&pairs).unwrap();
-        let table: Vec<String> = postcard::from_bytes(&decompress_deflate(include_bytes!(
-            "../../generated/caniuse_region_version_table.bin.deflate"
-        )))
-        .unwrap();
+            load(include_bytes!("../../generated/caniuse_region_pairs.bin.deflate"));
+        let table: Vec<String> =
+            load(include_bytes!("../../generated/caniuse_region_version_table.bin.deflate"));
         let versions = version_indices.into_iter().map(|i| table[i as usize].clone()).collect();
         (browsers, versions)
     })
@@ -45,11 +46,7 @@ impl RegionData {
         // The blob is two byte planes — every low byte, then every high byte — so its length is
         // twice the datum count; split there and recombine `lo | hi << 8`. The range bounds
         // address the planes directly (one slot per datum).
-        let pair_data = PAIR_INDICES.get_or_init(|| {
-            decompress_deflate(include_bytes!(
-                "../../generated/caniuse_region_pair_indices.bin.deflate"
-            ))
-        });
+        let pair_data = PAIR_INDICES.get();
         let pair_count = pair_data.len() / 2;
         let (pair_lo, pair_hi) = pair_data.split_at(pair_count);
         let pair_indices =
@@ -59,11 +56,7 @@ impl RegionData {
         // addressed by the same element offsets — but split three ways (low, middle, high) to hold
         // the per-datum deltas. Recombine each delta, then undo the delta in place (the values are
         // a non-increasing sequence stored as `prev - curr`).
-        let percentages_data = PERCENTAGES.get_or_init(|| {
-            decompress_deflate(include_bytes!(
-                "../../generated/caniuse_region_percentages.bin.deflate"
-            ))
-        });
+        let percentages_data = PERCENTAGES.get();
         let pct_count = percentages_data.len() / 3;
         let (pct_lo, rest) = percentages_data.split_at(pct_count);
         let (pct_mid, pct_hi) = rest.split_at(pct_count);

--- a/src/data/node.rs
+++ b/src/data/node.rs
@@ -8,9 +8,9 @@ pub use crate::generated::node_release_schedule::RELEASE_SCHEDULE;
 pub fn NODE_VERSIONS() -> &'static [Version] {
     static NODE_VERSIONS: OnceLock<Vec<Version>> = OnceLock::new();
     NODE_VERSIONS.get_or_init(|| {
-        const COMPRESSED: &[u8] = include_bytes!("../generated/node_versions.bin.deflate");
-        let decompressed = super::caniuse::compression::decompress_deflate(COMPRESSED);
-        let versions: Vec<(u16, u16, u16)> = postcard::from_bytes(&decompressed).unwrap();
+        let versions: Vec<(u16, u16, u16)> = super::caniuse::compression::load(include_bytes!(
+            "../generated/node_versions.bin.deflate"
+        ));
         versions.into_iter().map(|(major, minor, patch)| Version(major, minor, patch)).collect()
     })
 }

--- a/src/generated/caniuse_feature_matching.rs
+++ b/src/generated/caniuse_feature_matching.rs
@@ -1,6 +1,6 @@
-use crate::data::caniuse::{compression::decompress_deflate, features::Feature};
-use std::sync::OnceLock;
-static KEYS: OnceLock<Vec<String>> = OnceLock::new();
+use crate::data::caniuse::{compression::LazyData, features::Feature};
+static KEYS: LazyData<Vec<String>> =
+    LazyData::new(include_bytes!("caniuse_feature_keys.bin.deflate"));
 static RANGES: &[u32] = &[
     0u32, 95u32, 173u32, 194u32, 240u32, 338u32, 360u32, 381u32, 462u32, 541u32, 620u32, 698u32,
     776u32, 855u32, 924u32, 1006u32, 1084u32, 1182u32, 1279u32, 1359u32, 1387u32, 1477u32, 1550u32,
@@ -68,13 +68,7 @@ static RANGES: &[u32] = &[
     44786u32,
 ];
 pub fn get_feature_stat(name: &str) -> Option<Feature> {
-    let keys = KEYS.get_or_init(|| {
-        postcard::from_bytes(&decompress_deflate(include_bytes!(
-            "caniuse_feature_keys.bin.deflate"
-        )))
-        .unwrap()
-    });
-    match keys.binary_search_by(|key| key.as_str().cmp(name)) {
+    match KEYS.get().binary_search_by(|key| key.as_str().cmp(name)) {
         Ok(idx) => {
             let start = RANGES[idx];
             let end = RANGES[idx + 1];

--- a/src/generated/caniuse_region_matching.rs
+++ b/src/generated/caniuse_region_matching.rs
@@ -1,6 +1,6 @@
-use crate::data::caniuse::{compression::decompress_deflate, region::RegionData};
-use std::sync::OnceLock;
-static KEYS: OnceLock<Vec<String>> = OnceLock::new();
+use crate::data::caniuse::{compression::LazyData, region::RegionData};
+static KEYS: LazyData<Vec<String>> =
+    LazyData::new(include_bytes!("caniuse_region_keys.bin.deflate"));
 const RANGES: &[u32] = &[
     0u32, 174u32, 396u32, 651u32, 821u32, 970u32, 1193u32, 1404u32, 1665u32, 1874u32, 1994u32,
     2259u32, 2498u32, 2661u32, 2802u32, 3009u32, 3227u32, 3418u32, 3635u32, 3880u32, 4103u32,
@@ -31,10 +31,6 @@ const RANGES: &[u32] = &[
     47345u32,
 ];
 pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
-    let keys = KEYS.get_or_init(|| {
-        postcard::from_bytes(&decompress_deflate(include_bytes!("caniuse_region_keys.bin.deflate")))
-            .unwrap()
-    });
-    let index = keys.binary_search_by(|key| key.as_str().cmp(region)).ok()?;
+    let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(region)).ok()?;
     Some(RegionData::new(RANGES[index], RANGES[index + 1]))
 }

--- a/xtask/src/generators/caniuse/features.rs
+++ b/xtask/src/generators/caniuse/features.rs
@@ -140,19 +140,14 @@ pub fn build_caniuse_feature_matching(data: &Caniuse) -> Result<()> {
     let data_range = create_range_vec(&data);
 
     let output = quote! {
-        use std::sync::OnceLock;
+        use crate::data::caniuse::{compression::LazyData, features::Feature};
 
-        use crate::data::caniuse::{compression::decompress_deflate, features::Feature};
-
-        static KEYS: OnceLock<Vec<String>> = OnceLock::new();
+        static KEYS: LazyData<Vec<String>> =
+            LazyData::new(include_bytes!("caniuse_feature_keys.bin.deflate"));
         static RANGES: &[u32] = &[#(#data_range),*];
 
         pub fn get_feature_stat(name: &str) -> Option<Feature> {
-            let keys = KEYS.get_or_init(|| {
-                postcard::from_bytes(&decompress_deflate(include_bytes!("caniuse_feature_keys.bin.deflate")))
-                    .unwrap()
-            });
-            match keys.binary_search_by(|key| key.as_str().cmp(name)) {
+            match KEYS.get().binary_search_by(|key| key.as_str().cmp(name)) {
                 Ok(idx) => {
                     let start = RANGES[idx];
                     let end = RANGES[idx + 1];

--- a/xtask/src/generators/caniuse/regions.rs
+++ b/xtask/src/generators/caniuse/regions.rs
@@ -143,21 +143,16 @@ pub fn build_caniuse_region_matching(data: &Caniuse) -> Result<()> {
     save_bin_compressed("caniuse_region_percentages.bin", &percent_bytes);
 
     let output = quote! {
-        use std::sync::OnceLock;
+        use crate::data::caniuse::{compression::LazyData, region::RegionData};
 
-        use crate::data::caniuse::{compression::decompress_deflate, region::RegionData};
-
-        static KEYS: OnceLock<Vec<String>> = OnceLock::new();
+        static KEYS: LazyData<Vec<String>> =
+            LazyData::new(include_bytes!("caniuse_region_keys.bin.deflate"));
         // One element offset per region into both the pair-index and percentage byte planes
         // (the two share the same per-region datum count, so a single range table serves both).
         const RANGES: &[u32] = &[#(#pair_ranges,)*];
 
         pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
-            let keys = KEYS.get_or_init(|| {
-                postcard::from_bytes(&decompress_deflate(include_bytes!("caniuse_region_keys.bin.deflate")))
-                    .unwrap()
-            });
-            let index = keys.binary_search_by(|key| key.as_str().cmp(region)).ok()?;
+            let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(region)).ok()?;
             Some(RegionData::new(RANGES[index], RANGES[index + 1]))
         }
     };


### PR DESCRIPTION
Every compressed blob was loaded with ad-hoc `OnceLock` + inline `postcard::from_bytes(&decompress_deflate(include_bytes!(…)))` boilerplate — repeated and slightly varied across ~10 call sites plus the two generated loaders. This consolidates them behind three small helpers in `compression.rs`:

- **`LazyData<T>`** — a blob decompressed + postcard-deserialized into `T` on first use and cached. For values consumed as-is: the feature/region version tables, the per-browser version order, and the generated key tables.
- **`LazyBlob`** — a blob decompressed to raw bytes and cached, for data decoded by hand at the use site (the byte-plane and run-length blobs, where a generic deserializer would bloat the binary).
- **`load<T>`** — one-shot decompress + deserialize, shared by `LazyData` and by the few sites that transform the decoded value further (node versions, the browser map, the region pair table).

Call sites lose their hand-written accessor functions and become uniform `static X: LazyData<…> = LazyData::new(include_bytes!(…))` / `X.get()`. The remaining `OnceLock`s now cache only *derived/transformed* values (e.g. the browser `FxHashMap`, version aliases), and their blob loads route through `load()`.

### No data/behavior change, small size win
Blobs are byte-identical (regenerated). Sharing the loaders de-duplicates the per-site monomorphized closures, so the musl `inspect` example drops **764,160 → 761,920 B (−2,240)**. All tests and the JS-equivalence proptests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)