### PR TITLE
DRY up feature/region codegen with shared table + lookup helpers

### DIFF
--- a/src/generated/caniuse_feature_matching.rs
+++ b/src/generated/caniuse_feature_matching.rs
@@ -68,12 +68,6 @@ static RANGES: &[u32] = &[
     44786u32,
 ];
 pub fn get_feature_stat(name: &str) -> Option<Feature> {
-    match KEYS.get().binary_search_by(|key| key.as_str().cmp(name)) {
-        Ok(idx) => {
-            let start = RANGES[idx];
-            let end = RANGES[idx + 1];
-            Some(Feature::new(start, end))
-        }
-        Err(_) => None,
-    }
+    let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(name)).ok()?;
+    Some(Feature::new(RANGES[index], RANGES[index + 1]))
 }

--- a/src/generated/caniuse_region_matching.rs
+++ b/src/generated/caniuse_region_matching.rs
@@ -1,7 +1,7 @@
 use crate::data::caniuse::{compression::LazyData, region::RegionData};
 static KEYS: LazyData<Vec<String>> =
     LazyData::new(include_bytes!("caniuse_region_keys.bin.deflate"));
-const RANGES: &[u32] = &[
+static RANGES: &[u32] = &[
     0u32, 174u32, 396u32, 651u32, 821u32, 970u32, 1193u32, 1404u32, 1665u32, 1874u32, 1994u32,
     2259u32, 2498u32, 2661u32, 2802u32, 3009u32, 3227u32, 3418u32, 3635u32, 3880u32, 4103u32,
     4341u32, 4553u32, 4775u32, 5009u32, 5122u32, 5327u32, 5523u32, 5742u32, 5891u32, 6095u32,
@@ -30,7 +30,7 @@ const RANGES: &[u32] = &[
     45474u32, 45717u32, 45926u32, 46024u32, 46250u32, 46480u32, 46712u32, 46919u32, 47112u32,
     47345u32,
 ];
-pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
-    let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(region)).ok()?;
+pub fn get_usage_by_region(name: &str) -> Option<RegionData> {
+    let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(name)).ok()?;
     Some(RegionData::new(RANGES[index], RANGES[index + 1]))
 }

--- a/xtask/src/generators/caniuse/features.rs
+++ b/xtask/src/generators/caniuse/features.rs
@@ -2,10 +2,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::Result;
 use postcard::to_allocvec;
-use quote::quote;
 
 use crate::data::{Caniuse, encode_browser_name};
-use crate::utils::{create_range_vec, generate_file, save_bin_compressed};
+use crate::utils::{create_range_vec, generate_keyed_lookup, intern_table, save_bin_compressed};
 
 pub fn build_caniuse_feature_matching(data: &Caniuse) -> Result<()> {
     let mut sorted_data = data.data.clone();
@@ -40,29 +39,19 @@ pub fn build_caniuse_feature_matching(data: &Caniuse) -> Result<()> {
         })
         .collect::<Vec<_>>();
 
-    // Store the feature-name lookup keys as a compressed blob rather than an inline
-    // `&[&str]`: the slice would cost 16 bytes of (relocated) fat pointer per entry plus the
-    // raw string bytes, all uncompressed in the binary. The blob is decoded once on first use.
+    // The feature-name lookup keys and the per-feature data are written together at the end by
+    // `generate_keyed_lookup`; collect the (already sorted) keys here.
     let keys = sorted_data.keys().cloned().collect::<Vec<String>>();
-    save_bin_compressed("caniuse_feature_keys.bin", &to_allocvec(&keys).unwrap());
 
     // The `y`/`a` lists hold version strings drawn from a small shared vocabulary that repeats
     // across every feature. Intern them into one lexicographically-sorted table and store u16
     // indices instead. Because the table is sorted, each (already lexicographically-sorted) list
     // becomes a strictly ascending index sequence — compact for deflate and still correctly
     // ordered for the runtime's binary searches.
-    let mut all_versions = BTreeSet::new();
-    for feature in &features {
-        for (_, y, a) in feature {
-            all_versions.extend(y.iter().cloned());
-            all_versions.extend(a.iter().cloned());
-        }
-    }
-    let version_table: Vec<String> = all_versions.into_iter().collect();
-    let version_to_index: HashMap<&str, u16> =
-        version_table.iter().enumerate().map(|(i, v)| (v.as_str(), i as u16)).collect();
-    let table_bytes = to_allocvec(&version_table).unwrap();
-    save_bin_compressed("caniuse_feature_version_table.bin", &table_bytes);
+    let (version_table, version_to_index) = intern_table(
+        "caniuse_feature_version_table.bin",
+        features.iter().flat_map(|f| f.iter().flat_map(|(_, y, a)| y.iter().chain(a).cloned())),
+    );
 
     // A feature's per-browser `y`/`a` list is the set of versions that support it, and browser
     // support is almost always "from version N onward" — so in per-browser version order the list
@@ -138,27 +127,15 @@ pub fn build_caniuse_feature_matching(data: &Caniuse) -> Result<()> {
     save_bin_compressed("caniuse_feature_matching.bin", &data_bytes);
 
     let data_range = create_range_vec(&data);
-
-    let output = quote! {
-        use crate::data::caniuse::{compression::LazyData, features::Feature};
-
-        static KEYS: LazyData<Vec<String>> =
-            LazyData::new(include_bytes!("caniuse_feature_keys.bin.deflate"));
-        static RANGES: &[u32] = &[#(#data_range),*];
-
-        pub fn get_feature_stat(name: &str) -> Option<Feature> {
-            match KEYS.get().binary_search_by(|key| key.as_str().cmp(name)) {
-                Ok(idx) => {
-                    let start = RANGES[idx];
-                    let end = RANGES[idx + 1];
-                    Some(Feature::new(start, end))
-                },
-                Err(_) => None,
-            }
-        }
-    };
-
-    generate_file("caniuse_feature_matching.rs", output);
+    generate_keyed_lookup(
+        "caniuse_feature_matching.rs",
+        "caniuse_feature_keys.bin",
+        &keys,
+        &data_range,
+        "features",
+        "Feature",
+        "get_feature_stat",
+    );
 
     Ok(())
 }

--- a/xtask/src/generators/caniuse/regions.rs
+++ b/xtask/src/generators/caniuse/regions.rs
@@ -1,11 +1,10 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 use anyhow::Result;
 use postcard::to_allocvec;
-use quote::quote;
 
 use crate::data::{Caniuse, encode_browser_name};
-use crate::utils::{generate_file, save_bin_compressed};
+use crate::utils::{generate_keyed_lookup, intern_table, save_bin_compressed};
 
 struct RegionDatum {
     browser: u8,
@@ -46,25 +45,15 @@ pub fn build_caniuse_region_matching(data: &Caniuse) -> Result<()> {
 
     data.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-    // Store region-code lookup keys as a compressed blob instead of an inline `&[&str]`
-    // (16-byte fat pointer + raw bytes per entry, uncompressed). Decoded once on first use.
+    // The region-code lookup keys are written together with the per-region data at the end by
+    // `generate_keyed_lookup`; collect the (already sorted) keys here.
     let keys = data.iter().map(|(key, _)| key.clone()).collect::<Vec<String>>();
-    save_bin_compressed("caniuse_region_keys.bin", &to_allocvec(&keys).unwrap());
 
-    // Build version string intern table (deduplicated, sorted)
-    let mut all_versions = BTreeSet::new();
-    for (_, datums) in &data {
-        for datum in datums {
-            all_versions.insert(datum.version.clone());
-        }
-    }
-    let version_table: Vec<String> = all_versions.into_iter().collect();
-    let version_to_index: HashMap<&str, u16> =
-        version_table.iter().enumerate().map(|(i, v)| (v.as_str(), i as u16)).collect();
-
-    // Serialize and compress the string table
-    let table_bytes = to_allocvec(&version_table).unwrap();
-    save_bin_compressed("caniuse_region_version_table.bin", &table_bytes);
+    // Intern the version strings into one deduplicated, sorted table and remap to u16 indices.
+    let (_, version_to_index) = intern_table(
+        "caniuse_region_version_table.bin",
+        data.iter().flat_map(|(_, datums)| datums.iter().map(|datum| datum.version.clone())),
+    );
 
     // Only a few hundred distinct (browser, version) pairs exist, yet they recur ~47k times
     // across all regions. Intern them into one global table and store a single u16 pair-index
@@ -142,21 +131,18 @@ pub fn build_caniuse_region_matching(data: &Caniuse) -> Result<()> {
     percent_bytes.append(&mut percent_hi);
     save_bin_compressed("caniuse_region_percentages.bin", &percent_bytes);
 
-    let output = quote! {
-        use crate::data::caniuse::{compression::LazyData, region::RegionData};
-
-        static KEYS: LazyData<Vec<String>> =
-            LazyData::new(include_bytes!("caniuse_region_keys.bin.deflate"));
-        // One element offset per region into both the pair-index and percentage byte planes
-        // (the two share the same per-region datum count, so a single range table serves both).
-        const RANGES: &[u32] = &[#(#pair_ranges,)*];
-
-        pub fn get_usage_by_region(region: &str) -> Option<RegionData> {
-            let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(region)).ok()?;
-            Some(RegionData::new(RANGES[index], RANGES[index + 1]))
-        }
-    };
-    generate_file("caniuse_region_matching.rs", output);
+    // The generated `RANGES` holds one element offset per region into both the pair-index and
+    // percentage byte planes (the two share the same per-region datum count, so one table serves
+    // both).
+    generate_keyed_lookup(
+        "caniuse_region_matching.rs",
+        "caniuse_region_keys.bin",
+        &keys,
+        &pair_ranges,
+        "region",
+        "RegionData",
+        "get_usage_by_region",
+    );
 
     Ok(())
 }

--- a/xtask/src/utils/file.rs
+++ b/xtask/src/utils/file.rs
@@ -1,5 +1,8 @@
+use std::collections::{BTreeSet, HashMap};
 use std::fs;
 
+use postcard::to_allocvec;
+use quote::{format_ident, quote};
 use zopfli::{Format, Options};
 
 use super::paths::root;
@@ -31,4 +34,48 @@ pub fn create_range_vec(v: &Vec<Vec<u8>>) -> Vec<u32> {
     }
     ranges.push(offset as u32);
     ranges
+}
+
+/// Deduplicate and lexicographically sort `values` into a string intern table, save it as a
+/// compressed blob, and return the table alongside a value -> `u16` index map for remapping data.
+/// Both the feature and region generators intern their version strings this way.
+pub fn intern_table(
+    blob: &str,
+    values: impl IntoIterator<Item = String>,
+) -> (Vec<String>, HashMap<String, u16>) {
+    let table: Vec<String> = values.into_iter().collect::<BTreeSet<_>>().into_iter().collect();
+    save_bin_compressed(blob, &to_allocvec(&table).unwrap());
+    let index = table.iter().enumerate().map(|(i, v)| (v.clone(), i as u16)).collect();
+    (table, index)
+}
+
+/// Save a lookup-key table and emit the matching `get_*` accessor module. The feature and region
+/// matchers share this shape: binary-search a compressed key table for `name`, then build
+/// `<module>::<value_type>` from the surrounding `(start, end)` slice of `RANGES`.
+pub fn generate_keyed_lookup(
+    out_rs: &str,
+    keys_blob: &str,
+    keys: &[String],
+    ranges: &[u32],
+    module: &str,
+    value_type: &str,
+    fn_name: &str,
+) {
+    save_bin_compressed(keys_blob, &to_allocvec(keys).unwrap());
+    let keys_file = format!("{keys_blob}.deflate");
+    let module = format_ident!("{module}");
+    let value_type = format_ident!("{value_type}");
+    let fn_name = format_ident!("{fn_name}");
+    let output = quote! {
+        use crate::data::caniuse::{compression::LazyData, #module::#value_type};
+
+        static KEYS: LazyData<Vec<String>> = LazyData::new(include_bytes!(#keys_file));
+        static RANGES: &[u32] = &[#(#ranges),*];
+
+        pub fn #fn_name(name: &str) -> Option<#value_type> {
+            let index = KEYS.get().binary_search_by(|key| key.as_str().cmp(name)).ok()?;
+            Some(#value_type::new(RANGES[index], RANGES[index + 1]))
+        }
+    };
+    generate_file(out_rs, output);
 }

--- a/xtask/src/utils/mod.rs
+++ b/xtask/src/utils/mod.rs
@@ -1,5 +1,7 @@
 pub mod file;
 pub mod paths;
 
-pub use file::{create_range_vec, generate_file, save_bin_compressed};
+pub use file::{
+    create_range_vec, generate_file, generate_keyed_lookup, intern_table, save_bin_compressed,
+};
 pub use paths::root;


### PR DESCRIPTION
The feature and region data generators each hand-rolled the same two patterns, which had drifted apart over time:

1. **Version-string intern table** — `BTreeSet` → sorted `Vec<String>` → value→index map → save blob.
2. **Keys blob + lookup function** — save a `_keys.bin` and emit a binary-search accessor. These had become *inconsistent*: the feature one used `match` + `static RANGES`, the region one used `.ok()?` + `const RANGES`.

This extracts two shared helpers in `xtask` utils:

- **`intern_table(blob, values)`** — dedup + lexicographically sort into a table, save it compressed, and return the table plus a value→`u16` index map.
- **`generate_keyed_lookup(...)`** — save a key table and emit the one standard accessor shape: binary-search the keys for `name`, then build `Struct::new(RANGES[i], RANGES[i + 1])`.

Both `build_caniuse_feature_matching` and `build_caniuse_region_matching` now call them, so `get_feature_stat` and `get_usage_by_region` are byte-for-byte identical in shape.

### No data change
Every `.deflate` blob is **byte-identical** (regenerated to confirm); only the generated lookup `.rs` style is unified. All tests and the JS-equivalence proptests pass; clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)