### PR TITLE
perf: avoid per-distrib String allocation when sorting resolve results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,19 +136,24 @@ fn apply_query_operation(
     }
 }
 
-// Optimized sorting that parses versions only once
+// Sort by (name ascending, version descending), then dedup.
+//
+// Each version is parsed exactly once (decorating each distrib with its parsed
+// `Copy` version), then the name is compared as borrowed `&str`. This keeps the
+// original "parse once" property while removing its `to_string()` sort key, which
+// allocated one `String` per distrib on every call.
 fn sort_and_dedup_distribs(distribs: &mut Vec<Distrib>) {
-    if distribs.is_empty() {
-        return;
+    if distribs.len() < 2 {
+        return; // 0 or 1 element is already sorted and unique
     }
 
-    // Use sort_by_cached_key to parse each version only once
-    distribs.sort_by_cached_key(|d| {
-        let version = d.version().parse::<semver::Version>().unwrap_or_default();
-        (d.name().to_string(), std::cmp::Reverse(version))
-    });
+    let mut keyed: Vec<(semver::Version, Distrib)> = std::mem::take(distribs)
+        .into_iter()
+        .map(|d| (d.version().parse::<semver::Version>().unwrap_or_default(), d))
+        .collect();
+    keyed.sort_by(|(va, a), (vb, b)| a.name().cmp(b.name()).then_with(|| vb.cmp(va)));
+    distribs.extend(keyed.into_iter().map(|(_, d)| d));
 
-    // Dedup in place
     distribs.dedup();
 }
 


### PR DESCRIPTION
## Summary

`resolve()` sorted its results with `sort_by_cached_key`, whose key `(d.name().to_string(), Reverse(version))` allocated a throwaway `String` per distrib on **every** call — even though `Distrib` names are `Cow::Borrowed(&'static str)`.

This decorates each distrib with its parsed version once, sorts by the borrowed `&str` name (version descending as the tiebreak), then undecorates — preserving the original "parse versions once" property while dropping the per-distrib `String` allocation.

## Results

Criterion `benches/resolve`, median wall-time vs `main`:

| query | before | after | change |
|---|---|---|---|
| `supports es6-module` | 63.7 µs | 46.0 µs | **−22%** |
| `node >= 8` | 29.1 µs | 23.0 µs | **−16%** |
| `> 0.5%` | 2.02 µs | 1.62 µs | **−16%** |
| `cover 99%` | 17.0 µs | 13.7 µs | **−15%** |
| `defaults, not dead` | 12.2 µs | 10.7 µs | **−11%** |

Allocations per call (measured with a counting global allocator) drop correspondingly — e.g. `cover 99%` 234 → 12, `supports es6-module` 522 → 68.

## Correctness

Output is identical to the previous implementation: stable sort, same `FromStr` version parse, and `String` vs `&str` comparison is byte-identical, so sort order and dedup semantics are unchanged. Verified with a public-API differential over 21 queries (including `and`/`not`/dedup combinations) and `cargo test --lib` / `--doc`.

Note: re-parsing the version inside the comparator instead of decorating was measured and **rejected** — it regressed `cover 99%` by ~95% (re-parsing on each name-tie costs more than the `String`s it saves).
