### PR TITLE
perf: decode bundled data with miniz_oxide directly, drop flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,16 +244,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,7 +395,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
- "simd-adler32",
 ]
 
 [[package]]
@@ -446,8 +435,8 @@ name = "oxc-browserslist"
 version = "3.0.6"
 dependencies = [
  "criterion2",
- "flate2",
  "js-sys",
+ "miniz_oxide",
  "pico-args",
  "postcard",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo = { level = "warn", priority = -1 }
 [workspace.dependencies]
 anyhow = "1"
 criterion2 = { version = "3", default-features = false }
-flate2 = "1"
+miniz_oxide = "0.8"
 indexmap = "2"
 json5 = "1.0"
 pico-args = "0.5.0"
@@ -60,7 +60,7 @@ name = "resolve"
 harness = false
 
 [dependencies]
-flate2 = { workspace = true }
+miniz_oxide = { workspace = true }
 postcard = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/src/data/caniuse/compression.rs
+++ b/src/data/caniuse/compression.rs
@@ -1,15 +1,10 @@
-use std::io::Read;
 use std::sync::OnceLock;
 
-use flate2::read::DeflateDecoder;
 use serde::de::DeserializeOwned;
 
-/// Decompress deflate-compressed data.
+/// Decompress raw-deflate-compressed data.
 pub fn decompress_deflate(compressed_data: &[u8]) -> Vec<u8> {
-    let mut decoder = DeflateDecoder::new(compressed_data);
-    let mut decompressed = Vec::new();
-    decoder.read_to_end(&mut decompressed).expect("Failed to decompress data");
-    decompressed
+    miniz_oxide::inflate::decompress_to_vec(compressed_data).expect("Failed to decompress data")
 }
 
 /// Decompress a bundled blob and postcard-deserialize it in one step. Used directly by the few

--- a/xtask/src/utils/file.rs
+++ b/xtask/src/utils/file.rs
@@ -10,8 +10,8 @@ use super::paths::root;
 pub fn save_bin_compressed(file: &str, bytes: &[u8]) {
     // Compress with Zopfli, a (deliberately slow, build-time-only) deflate-compatible encoder that
     // squeezes a few percent more out of every blob than a normal deflate encoder. The output is a
-    // standard raw-deflate stream, so the runtime decoder (`flate2::read::DeflateDecoder`) reads it
-    // unchanged and no consumer-facing dependency changes.
+    // standard raw-deflate stream, so the runtime decoder (`miniz_oxide::inflate::decompress_to_vec`)
+    // reads it unchanged and no consumer-facing dependency changes.
     let mut compressed = Vec::new();
     zopfli::compress(Options::default(), Format::Deflate, bytes, &mut compressed).unwrap();
     let file = format!("{}.deflate", file);


### PR DESCRIPTION
## Summary

The bundled caniuse/electron/node data is decompressed at runtime with `flate2::read::DeflateDecoder`. `flate2` is only a thin wrapper over `miniz_oxide`, which is already the actual decoder (a transitive dependency). This calls `miniz_oxide::inflate::decompress_to_vec` directly instead.

Because it's the **same** inflate engine, decompressed output is byte-identical — no decoder-correctness risk. Raw deflate needs no CRC/adler checksum, so this also drops three dependencies — `flate2`, `crc32fast`, and `simd-adler32` (only `miniz_oxide` → `adler2` remains).

## Size (release `inspect` example)

| target | before | after | change |
|---|---|---|---|
| musl x86_64 | 769,632 | 764,864 | **−4,768 B** |
| macOS arm64 | 635,376 | 618,848 | −16,528 B (crossed a 16 KB page) |

`.text` is −1.6 KiB; the rest of the musl delta is the `crc32fast` / `simd-adler32` `.rodata` lookup tables. macOS file size is 16 KB page-quantized, so musl is the honest signal.

## Correctness

`miniz_oxide::inflate::decompress_to_vec` is exactly what `flate2`'s `DeflateDecoder` calls internally, so every blob decompresses to identical bytes. All 127 lib unit tests + 6 doctests pass, and `cargo clippy --all-targets --all-features -- -D warnings` is clean.
