### PR TITLE
perf: cache formatted node version strings to avoid per-result allocation

### DIFF
--- a/src/data/node.rs
+++ b/src/data/node.rs
@@ -4,13 +4,24 @@ use crate::semver::Version;
 
 pub use crate::generated::node_release_schedule::RELEASE_SCHEDULE;
 
+/// Node.js versions, each paired with its formatted `major.minor.patch` string.
+///
+/// The string is built once here so node queries can hand out a borrowed `&'static str`
+/// instead of allocating a fresh `String` per result on every `resolve`.
 #[allow(non_snake_case)]
-pub fn NODE_VERSIONS() -> &'static [Version] {
-    static NODE_VERSIONS: OnceLock<Vec<Version>> = OnceLock::new();
+pub fn NODE_VERSIONS() -> &'static [(Version, Box<str>)] {
+    static NODE_VERSIONS: OnceLock<Vec<(Version, Box<str>)>> = OnceLock::new();
     NODE_VERSIONS.get_or_init(|| {
         let versions: Vec<(u16, u16, u16)> = super::caniuse::compression::load(include_bytes!(
             "../generated/node_versions.bin.deflate"
         ));
-        versions.into_iter().map(|(major, minor, patch)| Version(major, minor, patch)).collect()
+        versions
+            .into_iter()
+            .map(|(major, minor, patch)| {
+                let version = Version(major, minor, patch);
+                let text = version.to_string().into_boxed_str();
+                (version, text)
+            })
+            .collect()
     })
 }

--- a/src/queries/last_n_node.rs
+++ b/src/queries/last_n_node.rs
@@ -6,7 +6,7 @@ pub(super) fn last_n_node(count: usize) -> QueryResult {
         .iter()
         .rev()
         .take(count)
-        .map(|version| Distrib::new("node", version.to_string()))
+        .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/last_n_node_major.rs
+++ b/src/queries/last_n_node_major.rs
@@ -2,15 +2,16 @@ use super::{Distrib, QueryResult};
 use crate::data::node::NODE_VERSIONS;
 
 pub(super) fn last_n_node_major(count: usize) -> QueryResult {
-    let mut vec = NODE_VERSIONS().iter().rev().map(|version| version.major()).collect::<Vec<_>>();
+    let mut vec =
+        NODE_VERSIONS().iter().rev().map(|(version, _)| version.major()).collect::<Vec<_>>();
     vec.dedup();
     let minimum = vec.into_iter().nth(count - 1).unwrap_or_default();
 
     let distribs = NODE_VERSIONS()
         .iter()
-        .filter(|version| version.major() >= minimum)
+        .filter(|(version, _)| version.major() >= minimum)
         .rev()
-        .map(|version| Distrib::new("node", version.to_string()))
+        .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
 
     Ok(distribs)

--- a/src/queries/maintained_node.rs
+++ b/src/queries/maintained_node.rs
@@ -9,9 +9,9 @@ pub(super) fn maintained_node() -> QueryResult {
         .iter()
         .filter(|(_, start, end)| *start < now && now < *end)
         .filter_map(|(version, _, _)| {
-            NODE_VERSIONS().iter().rfind(|v| v.major() == version.major())
+            NODE_VERSIONS().iter().rfind(|(v, _)| v.major() == version.major())
         })
-        .map(|version| Distrib::new("node", version.to_string()))
+        .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
     Ok(versions)
 }

--- a/src/queries/node_accurate.rs
+++ b/src/queries/node_accurate.rs
@@ -17,7 +17,7 @@ pub(super) fn node_accurate(version_str: &str, opts: &Opts) -> QueryResult {
     let distribs = NODE_VERSIONS()
         .iter()
         .rev()
-        .find(|v| {
+        .find(|(v, _)| {
             if let Some(major) = major {
                 let major_eq = major == v.0;
                 if let Some(minor) = minor {
@@ -31,7 +31,7 @@ pub(super) fn node_accurate(version_str: &str, opts: &Opts) -> QueryResult {
             }
             false
         })
-        .map(|version| vec![Distrib::new("node", version.to_string())]);
+        .map(|(_, text)| vec![Distrib::new("node", text.as_ref())]);
     if opts.ignore_unknown_versions {
         Ok(distribs.unwrap_or_default())
     } else {

--- a/src/queries/node_bounded_range.rs
+++ b/src/queries/node_bounded_range.rs
@@ -6,11 +6,11 @@ use crate::data::node::NODE_VERSIONS;
 pub(super) fn node_bounded_range(from: &str, to: &str) -> QueryResult {
     let distribs = NODE_VERSIONS()
         .iter()
-        .filter(|version| {
+        .filter(|(version, _)| {
             matches!(version.loose_compare(from), Ordering::Greater | Ordering::Equal)
                 && matches!(version.loose_compare(to), Ordering::Less | Ordering::Equal)
         })
-        .map(|version| Distrib::new("node", version.to_string()))
+        .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
     Ok(distribs)
 }

--- a/src/queries/node_unbounded_range.rs
+++ b/src/queries/node_unbounded_range.rs
@@ -8,8 +8,8 @@ pub(super) fn node_unbounded_range(comparator: Comparator, version: &str) -> Que
         Version::from_str(version).map_err(|_| Error::UnknownNodejsVersion(version.to_string()))?;
     let distribs = NODE_VERSIONS()
         .iter()
-        .filter(|v| {
-            let ord = (*v).cmp(&version);
+        .filter(|(v, _)| {
+            let ord = v.cmp(&version);
             match comparator {
                 Comparator::Greater => matches!(ord, Ordering::Greater),
                 Comparator::Less => matches!(ord, Ordering::Less),
@@ -17,7 +17,7 @@ pub(super) fn node_unbounded_range(comparator: Comparator, version: &str) -> Que
                 Comparator::LessOrEqual => matches!(ord, Ordering::Less | Ordering::Equal),
             }
         })
-        .map(|version| Distrib::new("node", version.to_string()))
+        .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
     Ok(distribs)
 }


### PR DESCRIPTION
## Summary

Node.js versions are stored as numeric `Version(u16, u16, u16)` structs (decoded from the bundled blob), so every node query formatted each result into a fresh `String` with `version.to_string()` on **every** `resolve` — one allocation per returned version. Mapping the query layer showed node is the *only* family that allocates per result; every other query (browser, electron, cover, percentage, …) already borrows `&'static str` from bundled data.

This builds the `major.minor.patch` string **once**, when `NODE_VERSIONS` is first initialized, and stores it next to the `Version`. The six node query sites (`node_unbounded_range`, `node_bounded_range`, `node_accurate`, `last_n_node`, `last_n_node_major`, `maintained_node`) now hand out a borrowed `&'static str`.

## Results

Criterion `benches/resolve`:

| query | before | after | change |
|---|---|---|---|
| `node >= 8` | ~24 µs | 11.8 µs | **−51%** |

Other benchmarks are flat (within run-to-run noise) — the change touches only node files.

Allocations per call (counting global allocator):

| query | distribs | before | after |
|---|---|---|---|
| `node >= 8` | 305 | 318 | **13** |
| `node > 6.5` | 328 | 341 | **13** |
| `node <= 12` | 135 | 147 | **12** |
| `last 2 node major versions` | 14 | 22 | **8** |

## Correctness

Output is byte-identical — the cached string is the same `Version` `Display` formatting, just produced once instead of per call. Verified with a differential over the node query set (`node >=`/`<=`/`-`/accurate, `last N [major] versions`, `maintained node versions`): identical before/after. 127 lib unit tests + 6 doctests pass; `cargo clippy --all-targets --all-features -- -D warnings` clean.

Trade-off: the formatted strings (~8 KB for ~300 versions) are now cached for the process lifetime instead of re-allocated per call — a one-time cost in exchange for removing the per-result allocation.
