### PR TITLE
perf: use ASCII case conversion for region codes to drop Unicode tables

### DIFF
--- a/src/queries/cover_by_region.rs
+++ b/src/queries/cover_by_region.rs
@@ -3,7 +3,7 @@ use crate::{data::caniuse::region::get_usage_by_region, error::Error};
 
 pub(super) fn cover_by_region(coverage: f32, region: &str) -> QueryResult {
     let normalized_region =
-        if region.len() == 2 { region.to_uppercase() } else { region.to_lowercase() };
+        if region.len() == 2 { region.to_ascii_uppercase() } else { region.to_ascii_lowercase() };
 
     if let Some(region_data) = get_usage_by_region(&normalized_region) {
         let mut distribs = vec![];

--- a/src/queries/percentage_by_region.rs
+++ b/src/queries/percentage_by_region.rs
@@ -7,7 +7,7 @@ pub(super) fn percentage_by_region(
     region: &str,
 ) -> QueryResult {
     let normalized_region =
-        if region.len() == 2 { region.to_uppercase() } else { region.to_lowercase() };
+        if region.len() == 2 { region.to_ascii_uppercase() } else { region.to_ascii_lowercase() };
 
     if let Some(region_data) = get_usage_by_region(&normalized_region) {
         let distribs = region_data


### PR DESCRIPTION
## Summary

The region queries (`> 1% in US`, `cover 0.5% in alt-eu`, …) normalize the region code with `str::to_uppercase` / `str::to_lowercase`:

```rust
if region.len() == 2 { region.to_uppercase() } else { region.to_lowercase() }
```

These are **Unicode** case-conversion methods — they pull in `str::to_lowercase`/`to_uppercase` plus the `core::unicode` case-mapping data tables. cargo-bloat attributes ~5 KiB of `.text` to them, and the associated `.rodata` tables push the real cost to ~10 KiB. The two region query files are the *only* callers in the crate.

Region codes are always ASCII (ISO country codes and `alt-*` subregions), so `to_ascii_uppercase` / `to_ascii_lowercase` produce identical results with zero Unicode tables.

## Size (release `inspect` example)

| target | before | after | change |
|---|---|---|---|
| musl x86_64 | 763,840 | 753,664 | **−10,176 B** |
| macOS arm64 | 618,848 | 618,816 | −32 B (same 16 KB page) |

`.text` is −4.9 KiB; the rest of the musl delta is the Unicode case-mapping `.rodata` tables. macOS file size is 16 KB page-quantized, so musl is the signal.

## Correctness

For ASCII input, `to_ascii_*` is byte-for-byte identical to the Unicode `to_*`; a non-ASCII region was already invalid and still errors the same way. Verified with a differential over 12 mixed-case region queries (`US`/`us`/`Us`, `alt-eu`/`ALT-EU`/`Alt-EU`, …) — identical before/after. 127 lib unit tests + 6 doctests pass; `cargo clippy --all-targets --all-features -- -D warnings` clean.
