### PR TITLE
perf: use sort_unstable_by in sort_and_dedup_distribs to shrink .text

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,7 @@ fn sort_and_dedup_distribs(distribs: &mut Vec<Distrib>) {
         .into_iter()
         .map(|d| (d.version().parse::<semver::Version>().unwrap_or_default(), d))
         .collect();
-    keyed.sort_by(|(va, a), (vb, b)| a.name().cmp(b.name()).then_with(|| vb.cmp(va)));
+    keyed.sort_unstable_by(|(va, a), (vb, b)| a.name().cmp(b.name()).then_with(|| vb.cmp(va)));
     distribs.extend(keyed.into_iter().map(|(_, d)| d));
 
     distribs.dedup();


### PR DESCRIPTION
## Problem

`resolve`'s final dedup pass (`sort_and_dedup_distribs`) was the **only stable sort in the crate**. cargo-bloat on the musl `inspect` example attributed `core::slice::sort::stable::quicksort` (~3.4 KiB, the stable driftsort + its merge/scratch machinery) to `browserslist`. The plan calls for `sort_unstable` over `sort`.

## Change

One line — `sort_by` → `sort_unstable_by` with the **same comparator**. pdqsort is smaller than driftsort here.

```diff
-    keyed.sort_by(|(va, a), (vb, b)| a.name().cmp(b.name()).then_with(|| vb.cmp(va)));
+    keyed.sort_unstable_by(|(va, a), (vb, b)| a.name().cmp(b.name()).then_with(|| vb.cmp(va)));
```

## Size delta (musl `inspect`)

| | bytes |
|---|---|
| before | 753,664 |
| after | 752,736 |
| **delta** | **−928** (`.text` −848, `.eh_frame` +104) |

macOS: −32 B (same 16 KB page; README figure unchanged).

## Why it's behavior-neutral

Stable vs unstable could only diverge if two distribs shared a `name` and parsed to the same `Version` while differing as strings (the comparator ties on `name` + `version().parse::<Version>().unwrap_or_default()`, but `Distrib` equality is on the version string). The existing `dedup()` removes only **consecutive** equals, so the code is already correct *only if* that tie never occurs — i.e. unstable is identical whenever the code is correct today.

Verified directly because the integration suites compare as `HashSet` (order-insensitive): an **ordered differential** between the two builds over a stress corpus — large same-browser version lists, Safari `TP`, Android/iOS range versions, all combinators, both `mobile_to_desktop` modes — is **byte-identical** (308 rows). `cargo test --lib` (127) + `cargo test --doc` (6) pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)