### PR TITLE
chore: bump cargo-shear to 1.13.1

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: oxc-project/setup-rust@3d6fb132fbe7cdcb66bf8ec193911c2945369d12 # v1.0.17
         with:
           restore-cache: true
-          tools: just,cargo-shear@1
+          tools: just,cargo-shear@1.13.1
           components: rustfmt
       - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
         with:

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ _default:
 alias r := ready
 
 init:
-  cargo binstall watchexec-cli typos-cli cargo-shear -y
+  cargo binstall watchexec-cli typos-cli cargo-shear@1.13.1 -y
 
 ready:
   git diff --exit-code --quiet
@@ -19,7 +19,7 @@ ready:
   cargo test
 
 fmt:
-  -cargo shear --fix # remove all unused dependencies
+  -cargo shear --fix --check-test-targets # remove all unused dependencies
   cargo fmt
   vp fmt
 


### PR DESCRIPTION
Bumps cargo-shear to 1.13.1 and runs cargo shear with `--check-test-targets`.