### PR TITLE
ci: enable codspeed simulation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,5 +48,6 @@ jobs:
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         timeout-minutes: 15
         with:
+          simulation: true
           mode: instrumentation
           run: cargo codspeed run


### PR DESCRIPTION
Sets CodSpeed benchmark workflows to simulation mode.