### PR TITLE
ci: use codspeed mode input

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,6 +48,6 @@ jobs:
         uses: CodSpeedHQ/action@63f3e98b61959fe67f146a3ff022e4136fe9bb9c # v4.17.6
         timeout-minutes: 15
         with:
-          simulation: true
+          mode: simulation
           mode: instrumentation
           run: cargo codspeed run

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,5 +49,4 @@ jobs:
         timeout-minutes: 15
         with:
           mode: simulation
-          mode: instrumentation
           run: cargo codspeed run


### PR DESCRIPTION
Replaces the CodSpeed `simulation` input with `mode: simulation`.