### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ unimplemented = "warn"
 print_stdout = "warn" # Must be opt-in
 print_stderr = "warn" # Must be opt-in
 cargo = { level = "warn", priority = -1 }
+multiple_crate_versions = "allow"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/xtask/src/generators/caniuse/browsers.rs
+++ b/xtask/src/generators/caniuse/browsers.rs
@@ -3,9 +3,12 @@ use postcard::to_allocvec;
 
 use crate::{data::caniuse::Caniuse, utils::save_bin_compressed};
 
+type BrowserVersionData = (String, f32, Option<i64>);
+type BrowserData = (String, String, Vec<BrowserVersionData>);
+
 pub fn build_caniuse_browsers(data: &Caniuse) -> Result<()> {
     // Prepare data for serialization - convert IndexMap to Vec for compatibility
-    let browser_data: Vec<(String, String, Vec<(String, f32, Option<i64>)>)> = data
+    let browser_data: Vec<BrowserData> = data
         .agents
         .iter()
         .map(|(name, agent)| {

--- a/xtask/src/generators/node.rs
+++ b/xtask/src/generators/node.rs
@@ -74,7 +74,7 @@ pub fn build_node_release_schedule() -> Result<()> {
         .map(|(version, NodeScheduleRelease { start, end })| {
             let version = version.trim_start_matches('v');
             let version = version.split('.').collect::<Vec<_>>();
-            assert!(version.len() > 0);
+            assert!(!version.is_empty());
             let major: u16 = version[0].parse().unwrap();
             let minor: u16 = version.get(1).map(|v| v.parse().unwrap()).unwrap_or_default();
             let patch: u16 = version.get(2).map(|v| v.parse().unwrap()).unwrap_or_default();


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo clippy --workspace --all-targets --all-features`.
