### PR TITLE
chore: bump MSRV to 1.95.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ oxc-browserslist is a Rust port of [Browserslist](https://github.com/browserslis
 
 The project uses several tools for development:
 
-- **Rust**: Latest stable (MSRV: 1.86.0)
+- **Rust**: Latest stable (MSRV: 1.95.0)
 - **Node.js**: Version specified in `.node-version`
 - **Vite+ (`vp`)**: Manages Node.js, dependencies, and formatting (`vp install`, `vp fmt`)
 - **just**: Command runner (alternative to make)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ include = ["/benches", "/examples", "/src"]
 keywords = ["javascript", "web"]
 license = "MIT"
 repository = "https://github.com/oxc-project/oxc-browserslist"
-rust-version = "1.85.0"
+rust-version = "1.95.0"
 description = "Rust-ported Browserslist for Oxc."
 
 [workspace]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -351,14 +351,14 @@ impl<'a> Parser<'a> {
         let start = self.pos;
 
         // Try bounded: " 1.0 - 2.0"
-        if self.skip_whitespace1() {
-            if let Some(from) = self.parse_version() {
+        if self.skip_whitespace1()
+            && let Some(from) = self.parse_version()
+        {
+            self.skip_whitespace();
+            if self.eat(b'-') {
                 self.skip_whitespace();
-                if self.eat(b'-') {
-                    self.skip_whitespace();
-                    if let Some(to) = self.parse_version() {
-                        return Some(VersionRange::Bounded(from, to));
-                    }
+                if let Some(to) = self.parse_version() {
+                    return Some(VersionRange::Bounded(from, to));
                 }
             }
         }
@@ -375,10 +375,10 @@ impl<'a> Parser<'a> {
         self.pos = start;
 
         // Try accurate: " 1.0"
-        if self.skip_whitespace1() {
-            if let Some(ver) = self.parse_version() {
-                return Some(VersionRange::Accurate(ver));
-            }
+        if self.skip_whitespace1()
+            && let Some(ver) = self.parse_version()
+        {
+            return Some(VersionRange::Accurate(ver));
         }
         self.pos = start;
         None
@@ -399,10 +399,11 @@ impl<'a> Parser<'a> {
         let before_num = self.pos;
 
         // Try years first (has fractional)
-        if let Some(years) = self.parse_double() {
-            if self.skip_whitespace1() && self.match_year_keyword() {
-                return Some(QueryAtom::Years(years));
-            }
+        if let Some(years) = self.parse_double()
+            && self.skip_whitespace1()
+            && self.match_year_keyword()
+        {
+            return Some(QueryAtom::Years(years));
         }
         self.pos = before_num;
 

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -41,18 +41,14 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                         if versions.supports(version, include_partial) {
                             return Some(version);
                         }
-                        if check_desktop {
-                            if let Some(desktop_name) = desktop_name {
-                                if let Some(versions) =
-                                    feature.iter().find_map(|(name, versions)| {
-                                        (*name == desktop_name).then_some(versions)
-                                    })
-                                {
-                                    if versions.supports(version, include_partial) {
-                                        return Some(version);
-                                    }
-                                }
-                            }
+                        if check_desktop
+                            && let Some(desktop_name) = desktop_name
+                            && let Some(versions) = feature.iter().find_map(|(name, versions)| {
+                                (*name == desktop_name).then_some(versions)
+                            })
+                            && versions.supports(version, include_partial)
+                        {
+                            return Some(version);
                         }
                         None
                     })


### PR DESCRIPTION
Bump `rust-version` from 1.85.0 to 1.95.0 and update the stale MSRV mention in AGENTS.md (which said 1.86.0).

Includes the `clippy::collapsible_if` fixes (let chains, stabilized in 1.88) that the bump un-gates — clippy fails under `-D warnings` without them.

Follow-up PRs apply further code modernizations enabled by the new MSRV.