### PR TITLE
refactor: use `cast_signed` for integer sign casts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ oxc-browserslist is a Rust port of [Browserslist](https://github.com/browserslis
 
 The project uses several tools for development:
 
-- **Rust**: Latest stable (MSRV: 1.86.0)
+- **Rust**: Latest stable (MSRV: 1.95.0)
 - **Node.js**: Version specified in `.node-version`
 - **Vite+ (`vp`)**: Manages Node.js, dependencies, and formatting (`vp install`, `vp fmt`)
 - **just**: Command runner (alternative to make)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ include = ["/benches", "/examples", "/src"]
 keywords = ["javascript", "web"]
 license = "MIT"
 repository = "https://github.com/oxc-project/oxc-browserslist"
-rust-version = "1.85.0"
+rust-version = "1.95.0"
 description = "Rust-ported Browserslist for Oxc."
 
 [workspace]

--- a/src/date.rs
+++ b/src/date.rs
@@ -10,15 +10,14 @@ const UNIX_EPOCH_JDN: i64 = 2440588;
 /// Convert a calendar date to Julian Day Number.
 /// Uses the algorithm from <https://en.wikipedia.org/wiki/Julian_day#Converting_Gregorian_calendar_date_to_Julian_Day_Number>
 /// Returns None if the calculation would overflow.
-#[allow(clippy::cast_possible_truncation)]
 const fn date_to_julian_day(year: i32, month: u32, day: u32) -> Option<i32> {
-    let a = (14 - month as i32) / 12;
+    let a = (14 - month.cast_signed()) / 12;
     let Some(y) = year.checked_add(4800 - a) else { return None };
-    let m = month as i32 + 12 * a - 3;
+    let m = month.cast_signed() + 12 * a - 3;
     // Use checked arithmetic to prevent overflow
     let Some(term1) = 365_i32.checked_mul(y) else { return None };
     let Some(term2) = term1.checked_add((153 * m + 2) / 5) else { return None };
-    let Some(term3) = term2.checked_add(day as i32) else { return None };
+    let Some(term3) = term2.checked_add(day.cast_signed()) else { return None };
     let Some(term4) = term3.checked_add(y / 4) else { return None };
     let Some(term5) = term4.checked_sub(y / 100) else { return None };
     let Some(term6) = term5.checked_add(y / 400) else { return None };
@@ -39,7 +38,7 @@ pub fn date_to_unix_timestamp(year: i32, month: u32, day: u32) -> Option<i64> {
 pub fn now_unix_timestamp() -> i64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
+        .map(|d| d.as_secs().cast_signed())
         .unwrap_or(0)
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -351,14 +351,14 @@ impl<'a> Parser<'a> {
         let start = self.pos;
 
         // Try bounded: " 1.0 - 2.0"
-        if self.skip_whitespace1() {
-            if let Some(from) = self.parse_version() {
+        if self.skip_whitespace1()
+            && let Some(from) = self.parse_version()
+        {
+            self.skip_whitespace();
+            if self.eat(b'-') {
                 self.skip_whitespace();
-                if self.eat(b'-') {
-                    self.skip_whitespace();
-                    if let Some(to) = self.parse_version() {
-                        return Some(VersionRange::Bounded(from, to));
-                    }
+                if let Some(to) = self.parse_version() {
+                    return Some(VersionRange::Bounded(from, to));
                 }
             }
         }
@@ -375,10 +375,10 @@ impl<'a> Parser<'a> {
         self.pos = start;
 
         // Try accurate: " 1.0"
-        if self.skip_whitespace1() {
-            if let Some(ver) = self.parse_version() {
-                return Some(VersionRange::Accurate(ver));
-            }
+        if self.skip_whitespace1()
+            && let Some(ver) = self.parse_version()
+        {
+            return Some(VersionRange::Accurate(ver));
         }
         self.pos = start;
         None
@@ -399,10 +399,11 @@ impl<'a> Parser<'a> {
         let before_num = self.pos;
 
         // Try years first (has fractional)
-        if let Some(years) = self.parse_double() {
-            if self.skip_whitespace1() && self.match_year_keyword() {
-                return Some(QueryAtom::Years(years));
-            }
+        if let Some(years) = self.parse_double()
+            && self.skip_whitespace1()
+            && self.match_year_keyword()
+        {
+            return Some(QueryAtom::Years(years));
         }
         self.pos = before_num;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -237,7 +237,7 @@ impl<'a> Parser<'a> {
         if !neg {
             self.eat(b'+');
         }
-        let n = self.parse_u32()? as i32;
+        let n = self.parse_u32()?.cast_signed();
         Some(if neg { -n } else { n })
     }
 

--- a/src/queries/supports.rs
+++ b/src/queries/supports.rs
@@ -41,18 +41,14 @@ pub(super) fn supports(name: &str, kind: Option<SupportKind>, opts: &Opts) -> Qu
                         if versions.supports(version, include_partial) {
                             return Some(version);
                         }
-                        if check_desktop {
-                            if let Some(desktop_name) = desktop_name {
-                                if let Some(versions) =
-                                    feature.iter().find_map(|(name, versions)| {
-                                        (*name == desktop_name).then_some(versions)
-                                    })
-                                {
-                                    if versions.supports(version, include_partial) {
-                                        return Some(version);
-                                    }
-                                }
-                            }
+                        if check_desktop
+                            && let Some(desktop_name) = desktop_name
+                            && let Some(versions) = feature.iter().find_map(|(name, versions)| {
+                                (*name == desktop_name).then_some(versions)
+                            })
+                            && versions.supports(version, include_partial)
+                        {
+                            return Some(version);
                         }
                         None
                     })


### PR DESCRIPTION
Replace same-width `as` sign casts with `{integer}::cast_signed` (stabilized in Rust 1.87, const-stable since 1.87), which documents that the sign reinterpretation is intentional:

- `src/date.rs`: `month`/`day` `u32 -> i32` in `date_to_julian_day`, and `as_secs()` `u64 -> i64` in `now_unix_timestamp`
- `src/parser.rs`: `u32 -> i32` in `parse_i32`

Also drops the `#[allow(clippy::cast_possible_truncation)]` on `date_to_julian_day` — it was stale (nothing in that function triggers the lint).

Stacked on #776.