### PR TITLE
fix: align unbounded range queries with browserslist 4.28.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "vp config"
   },
   "dependencies": {
-    "browserslist": "4.28.4"
+    "browserslist": "4.28.6"
   },
   "devDependencies": {
     "vite-plus": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
   .:
     dependencies:
       browserslist:
-        specifier: 4.28.4
-        version: 4.28.4
+        specifier: 4.28.6
+        version: 4.28.6
       caniuse-lite:
         specifier: 1.x
         version: 1.0.30001805
@@ -753,8 +753,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  browserslist@4.28.4:
-    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1515,13 +1515,13 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
-  browserslist@4.28.4:
+  browserslist@4.28.6:
     dependencies:
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
       electron-to-chromium: 1.5.389
       node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.4)
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
 
   caniuse-lite@1.0.30001805: {}
 
@@ -1756,9 +1756,9 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  update-browserslist-db@1.2.3(browserslist@4.28.4):
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:
-      browserslist: 4.28.4
+      browserslist: 4.28.6
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/src/queries/browser_unbounded_range.rs
+++ b/src/queries/browser_unbounded_range.rs
@@ -18,9 +18,10 @@ pub(super) fn browser_unbounded_range(
         .get(name)
         .and_then(|alias| alias.get(version).copied())
         .unwrap_or(version);
-    let Some(version) = parse_js_float(version) else {
+    let Some(lower) = parse_js_float(version) else {
         return Ok(Vec::new());
     };
+    let upper = parse_latest_js_float(version).unwrap_or(lower);
 
     let distribs = stat
         .version_list
@@ -28,10 +29,10 @@ pub(super) fn browser_unbounded_range(
         .filter(|version| version.release_date().is_some())
         .map(|version| version.version())
         .filter(|v| match comparator {
-            Comparator::Greater => parse_latest_js_float(v).is_some_and(|v| v > version),
-            Comparator::Less => parse_js_float(v).is_some_and(|v| v < version),
-            Comparator::GreaterOrEqual => parse_latest_js_float(v).is_some_and(|v| v >= version),
-            Comparator::LessOrEqual => parse_js_float(v).is_some_and(|v| v <= version),
+            Comparator::Greater => parse_latest_js_float(v).is_some_and(|v| v > upper),
+            Comparator::Less => parse_js_float(v).is_some_and(|v| v < lower),
+            Comparator::GreaterOrEqual => parse_latest_js_float(v).is_some_and(|v| v >= upper),
+            Comparator::LessOrEqual => parse_js_float(v).is_some_and(|v| v <= lower),
         })
         .map(|version| Distrib::new(name, version))
         .collect();

--- a/tests/queries/electron_bounded_range.rs
+++ b/tests/queries/electron_bounded_range.rs
@@ -5,6 +5,7 @@ use test_case::test_case;
 #[test_case("electron 0.36-1.2"; "basic")]
 #[test_case("Electron 0.37-1.0"; "case insensitive")]
 #[test_case("electron 0.37.5-1.0.3"; "with semver patch version")]
+#[test_case("electron 37.9 - 37.10"; "compares range bounds as semver")]
 fn valid(query: &str) {
     run_compare(query, &Opts::default(), None);
 }


### PR DESCRIPTION
Bumps the `browserslist` test oracle to 4.28.6 and ports the two query fixes it contains. Supersedes #779.

**`>` / `>=` range-alias queries (4.28.5)** — when a query version resolves via an alias to a range (`samsung 5.0` → `5.0-5.4`), `>`/`>=` now compare against the range's upper bound, so `samsung > 5.0` no longer matches `samsung 5.0-5.4` itself. This is the case that failed CI on #779; fixed in `browser_unbounded_range`.

**Electron bounded ranges ([4.28.6](https://github.com/browserslist/browserslist/commit/a2168f7f884ac38b5974bd0cf3d4fc7e669a44ec))** — upstream switched `electron X - Y` from `parseFloat` to semver comparison, so minors like `37.10` no longer collapse to `37.1`. The Rust port is already correct here (`ElectronVersion` derives `Ord` over its `u16` fields), so no code change is needed — this just targets the 4.28.6 oracle and adds a regression test.

Full `cargo test` (incl. proptests + the new electron case), `fmt`, `clippy`, and `doc` are green.