### PR TITLE
fix(ci): skip lifecycle scripts when updating browser data

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           cache: true
 
-      - run: vp update --prod
+      - run: vp update --prod -- --ignore-scripts
 
       - run: cargo codegen
 


### PR DESCRIPTION
Pass `--ignore-scripts` through during scheduled production dependency updates. This prevents `prepare` from invoking Vite+ after `--prod` removes its dev-only native binding.

Validation: `just ready`