### PR TITLE
refactor: clean up code for idiomatic Rust

### DIFF
--- a/examples/inspect.rs
+++ b/examples/inspect.rs
@@ -20,5 +20,5 @@ fn main() {
             }
         }
         Err(error) => println!("{error}"),
-    };
+    }
 }

--- a/src/data/caniuse.rs
+++ b/src/data/caniuse.rs
@@ -182,31 +182,17 @@ pub fn browser_version_aliases()
         let mut aliases = caniuse_browsers()
             .iter()
             .filter_map(|(name, stat)| {
-                let aliases = stat
-                    .version_list
-                    .iter()
-                    .filter_map(|version| {
-                        version
-                            .version()
-                            .split_once('-')
-                            .map(|(bottom, top)| (bottom, top, version.version()))
-                    })
-                    .fold(
-                        FxHashMap::<&str, &str>::default(),
-                        move |mut aliases, (bottom, top, version)| {
-                            let _ = aliases.insert(bottom, version);
-                            let _ = aliases.insert(top, version);
-                            aliases
-                        },
-                    );
+                let mut aliases = FxHashMap::<&str, &str>::default();
+                for version in &stat.version_list {
+                    if let Some((bottom, top)) = version.version().split_once('-') {
+                        aliases.insert(bottom, version.version());
+                        aliases.insert(top, version.version());
+                    }
+                }
                 if aliases.is_empty() { None } else { Some((name.clone(), aliases)) }
             })
             .collect::<FxHashMap<Cow<'static, str>, _>>();
-        let _ = aliases.insert(Cow::Borrowed("op_mob"), {
-            let mut aliases = FxHashMap::default();
-            let _ = aliases.insert("59", "58");
-            aliases
-        });
+        aliases.insert(Cow::Borrowed("op_mob"), FxHashMap::from_iter([("59", "58")]));
         aliases
     })
 }
@@ -255,11 +241,7 @@ fn find_chrome_evergreen_start(chrome: &BrowserStat) -> usize {
         .version_list
         .iter()
         .position(|version| {
-            version
-                .version()
-                .parse::<usize>()
-                .map(|v| v == ANDROID_EVERGREEN_FIRST as usize)
-                .unwrap_or(false)
+            version.version().parse::<usize>().is_ok_and(|v| v == ANDROID_EVERGREEN_FIRST as usize)
         })
         .unwrap_or(0)
 }
@@ -287,10 +269,10 @@ fn get_browser_stat_mobile_to_desktop(name: &str) -> Option<(&'static str, &'sta
     // Reproduce original logic: first check if we have a desktop mapping
     match name {
         // Browsers that have desktop equivalents
-        "and_chr" => caniuse_browsers().get(&Cow::Borrowed("chrome")).map(|stat| ("and_chr", stat)),
+        "and_chr" => caniuse_browsers().get("chrome").map(|stat| ("and_chr", stat)),
         "android" => Some(("android", android_to_desktop())), // Special case for android
-        "and_ff" => caniuse_browsers().get(&Cow::Borrowed("firefox")).map(|stat| ("and_ff", stat)),
-        "ie_mob" => caniuse_browsers().get(&Cow::Borrowed("ie")).map(|stat| ("ie_mob", stat)),
+        "and_ff" => caniuse_browsers().get("firefox").map(|stat| ("and_ff", stat)),
+        "ie_mob" => caniuse_browsers().get("ie").map(|stat| ("ie_mob", stat)),
         // All other browsers (including op_mob) return their own data
         _ => caniuse_browsers().get(name).map(|stat| (stat.name.as_ref(), stat)),
     }
@@ -320,7 +302,7 @@ fn get_browser_alias_lowercase(name: &str) -> Cow<'static, str> {
     if let Some(alias) = resolve_alias(&lowercase) {
         return Cow::Borrowed(alias);
     }
-    if caniuse_browsers().contains_key(&Cow::Owned(lowercase.clone())) {
+    if caniuse_browsers().contains_key(lowercase.as_str()) {
         Cow::Owned(lowercase)
     } else {
         Cow::Owned(name.to_string())

--- a/src/data/electron.rs
+++ b/src/data/electron.rs
@@ -69,12 +69,11 @@ pub fn parse_version(version: &str) -> Result<ElectronVersion, Error> {
         return Err(err(version));
     }
 
-    let election_version = ElectronVersion::parse(first, second).map_err(|_| err(version))?;
-    Ok(election_version)
+    ElectronVersion::parse(first, second).map_err(|_| err(version))
 }
 
 fn check_number(n: &str) -> bool {
-    if n == "0" { true } else { !n.starts_with('0') }
+    n == "0" || !n.starts_with('0')
 }
 
 fn err(version: &str) -> Error {

--- a/src/data/node.rs
+++ b/src/data/node.rs
@@ -50,8 +50,7 @@ fn node_data() -> &'static NodeData {
 }
 
 /// Node.js versions, each paired with its formatted `major.minor.patch` string.
-#[allow(non_snake_case)]
-pub fn NODE_VERSIONS() -> &'static [(Version, Box<str>)] {
+pub fn node_versions() -> &'static [(Version, Box<str>)] {
     &node_data().versions
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,28 +86,27 @@ pub fn resolve<S>(queries: &[S], opts: &Opts) -> Result<Vec<Distrib>, Error>
 where
     S: AsRef<str>,
 {
-    match queries.len() {
-        1 => _resolve(queries[0].as_ref(), opts),
-        _ => {
-            // Pre-calculate capacity to avoid reallocations
-            let total_len: usize = queries.iter().map(|q| q.as_ref().len() + 1).sum();
-            let mut s = String::with_capacity(total_len);
-            for (i, q) in queries.iter().enumerate() {
-                if i > 0 {
-                    s.push(',');
-                }
-                s.push_str(q.as_ref());
+    if let [query] = queries {
+        resolve_impl(query.as_ref(), opts)
+    } else {
+        // Pre-calculate capacity to avoid reallocations
+        let total_len: usize = queries.iter().map(|q| q.as_ref().len() + 1).sum();
+        let mut s = String::with_capacity(total_len);
+        for (i, q) in queries.iter().enumerate() {
+            if i > 0 {
+                s.push(',');
             }
-            _resolve(&s, opts)
+            s.push_str(q.as_ref());
         }
+        resolve_impl(&s, opts)
     }
 }
 
 // reduce generic monomorphization
-fn _resolve(query: &str, opts: &Opts) -> Result<Vec<Distrib>, Error> {
+fn resolve_impl(query: &str, opts: &Opts) -> Result<Vec<Distrib>, Error> {
     let queries = parse_browserslist_query(query)?;
     let mut distribs = vec![];
-    for (i, current) in queries.1.into_iter().enumerate() {
+    for (i, current) in queries.into_iter().enumerate() {
         if i == 0 && current.negated {
             return handle_first_negated_error(current.raw.to_string());
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -38,13 +38,13 @@ pub enum Stats<'a> {
     Region(&'a str),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum SupportKind {
     Fully,
     Partially,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Comparator {
     Less,
     LessOrEqual,
@@ -53,7 +53,7 @@ pub enum Comparator {
 }
 
 impl Comparator {
-    pub fn compare_f32(&self, value: f32, target: f32) -> bool {
+    pub fn compare<T: PartialOrd>(self, value: T, target: T) -> bool {
         match self {
             Self::Greater => value > target,
             Self::GreaterOrEqual => value >= target,
@@ -166,18 +166,18 @@ impl<'a> Parser<'a> {
         false
     }
 
+    /// Match a keyword with an optional trailing `s` (e.g. `version`/`versions`).
     #[inline]
-    fn match_version_keyword(&mut self) -> bool {
-        let end = self.pos + 7;
+    fn match_plural_keyword(&mut self, kw: &[u8]) -> bool {
+        let end = self.pos + kw.len();
         if end > self.bytes.len() {
             return false;
         }
         let slice = &self.bytes[self.pos..end];
-        if !slice.eq_ignore_ascii_case(b"version") {
+        if !slice.eq_ignore_ascii_case(kw) {
             return false;
         }
         self.pos = end;
-        // Optional 's'
         if self.pos < self.bytes.len() && matches!(self.peek(), b's' | b'S') {
             self.pos += 1;
         }
@@ -189,23 +189,13 @@ impl<'a> Parser<'a> {
     }
 
     #[inline]
+    fn match_version_keyword(&mut self) -> bool {
+        self.match_plural_keyword(b"version")
+    }
+
+    #[inline]
     fn match_year_keyword(&mut self) -> bool {
-        let end = self.pos + 4;
-        if end > self.bytes.len() {
-            return false;
-        }
-        let slice = &self.bytes[self.pos..end];
-        if !slice.eq_ignore_ascii_case(b"year") {
-            return false;
-        }
-        self.pos = end;
-        if self.pos < self.bytes.len() && matches!(self.peek(), b's' | b'S') {
-            self.pos += 1;
-        }
-        self.pos >= self.bytes.len() || {
-            let b = self.peek();
-            !b.is_ascii_alphanumeric() && b != b'_'
-        }
+        self.match_plural_keyword(b"year")
     }
 
     /// Parse unsigned integer directly from bytes
@@ -272,8 +262,9 @@ impl<'a> Parser<'a> {
         Some(if neg { -n } else { n })
     }
 
+    /// Scan an optionally signed decimal number (e.g. `-1`, `2.5`, `.5`).
     #[inline]
-    fn parse_float(&mut self) -> Option<f32> {
+    fn scan_number(&mut self) -> Option<&'a str> {
         let start = self.pos;
         let _ = self.eat(b'-') || self.eat(b'+');
         while self.pos < self.bytes.len() && self.peek().is_ascii_digit() {
@@ -284,22 +275,17 @@ impl<'a> Parser<'a> {
                 self.pos += 1;
             }
         }
-        if self.pos > start { self.slice(start, self.pos).parse().ok() } else { None }
+        if self.pos > start { Some(self.slice(start, self.pos)) } else { None }
+    }
+
+    #[inline]
+    fn parse_float(&mut self) -> Option<f32> {
+        self.scan_number()?.parse().ok()
     }
 
     #[inline]
     fn parse_double(&mut self) -> Option<f64> {
-        let start = self.pos;
-        let _ = self.eat(b'-') || self.eat(b'+');
-        while self.pos < self.bytes.len() && self.peek().is_ascii_digit() {
-            self.pos += 1;
-        }
-        if self.eat(b'.') {
-            while self.pos < self.bytes.len() && self.peek().is_ascii_digit() {
-                self.pos += 1;
-            }
-        }
-        if self.pos > start { self.slice(start, self.pos).parse().ok() } else { None }
+        self.scan_number()?.parse().ok()
     }
 
     #[inline]
@@ -329,6 +315,20 @@ impl<'a> Parser<'a> {
         while self.pos < self.bytes.len() {
             let b = self.peek();
             if !b.is_ascii_alphabetic() && b != b'_' {
+                break;
+            }
+            self.pos += 1;
+        }
+        if self.pos > start { Some(self.slice(start, self.pos)) } else { None }
+    }
+
+    /// Parse a feature name for `supports` queries (alphanumeric and `-`).
+    #[inline]
+    fn parse_feature_name(&mut self) -> Option<&'a str> {
+        let start = self.pos;
+        while self.pos < self.bytes.len() {
+            let b = self.peek();
+            if !b.is_ascii_alphanumeric() && b != b'-' {
                 break;
             }
             self.pos += 1;
@@ -534,11 +534,11 @@ impl<'a> Parser<'a> {
             self.pos = start;
             return None;
         }
-        if self.pos >= self.bytes.len() || !matches!(self.peek(), b' ' | b'\t') {
+        // Exactly one whitespace character, like the upstream `since` regex.
+        if !(self.eat(b' ') || self.eat(b'\t')) {
             self.pos = start;
             return None;
         }
-        self.pos += 1;
 
         let Some(year) = self.parse_i32() else {
             self.pos = start;
@@ -557,19 +557,11 @@ impl<'a> Parser<'a> {
             return None;
         }
 
-        let feat_start = self.pos;
-        while self.pos < self.bytes.len() {
-            let b = self.peek();
-            if !b.is_ascii_alphanumeric() && b != b'-' {
-                break;
-            }
-            self.pos += 1;
-        }
-        if self.pos == feat_start {
+        let Some(feature) = self.parse_feature_name() else {
             self.pos = start;
             return None;
-        }
-        Some(QueryAtom::Supports(self.slice(feat_start, self.pos), None))
+        };
+        Some(QueryAtom::Supports(feature, None))
     }
 
     fn parse_cover_or_current(&mut self) -> Option<QueryAtom<'a>> {
@@ -700,19 +692,11 @@ impl<'a> Parser<'a> {
             self.pos = start;
             return None;
         }
-        let feat_start = self.pos;
-        while self.pos < self.bytes.len() {
-            let b = self.peek();
-            if !b.is_ascii_alphanumeric() && b != b'-' {
-                break;
-            }
-            self.pos += 1;
-        }
-        if self.pos == feat_start {
+        let Some(feature) = self.parse_feature_name() else {
             self.pos = start;
             return None;
-        }
-        Some(QueryAtom::Supports(self.slice(feat_start, self.pos), Some(SupportKind::Fully)))
+        };
+        Some(QueryAtom::Supports(feature, Some(SupportKind::Fully)))
     }
 
     fn parse_operamini(&mut self) -> Option<QueryAtom<'a>> {
@@ -790,19 +774,11 @@ impl<'a> Parser<'a> {
             self.pos = start;
             return None;
         }
-        let feat_start = self.pos;
-        while self.pos < self.bytes.len() {
-            let b = self.peek();
-            if !b.is_ascii_alphanumeric() && b != b'-' {
-                break;
-            }
-            self.pos += 1;
-        }
-        if self.pos == feat_start {
+        let Some(feature) = self.parse_feature_name() else {
             self.pos = start;
             return None;
-        }
-        Some(QueryAtom::Supports(self.slice(feat_start, self.pos), Some(SupportKind::Partially)))
+        };
+        Some(QueryAtom::Supports(feature, Some(SupportKind::Partially)))
     }
 
     fn parse_defaults_or_dead(&mut self) -> Option<QueryAtom<'a>> {
@@ -1030,10 +1006,10 @@ impl<'a> Parser<'a> {
     }
 }
 
-pub fn parse_browserslist_query(input: &str) -> Result<(&str, Vec<SingleQuery<'_>>), &str> {
+pub fn parse_browserslist_query(input: &str) -> Result<Vec<SingleQuery<'_>>, &str> {
     let input = input.trim();
     if input.is_empty() {
-        return Ok(("", vec![]));
+        return Ok(vec![]);
     }
 
     let mut parser = Parser::new(input);
@@ -1052,7 +1028,7 @@ pub fn parse_browserslist_query(input: &str) -> Result<(&str, Vec<SingleQuery<'_
         queries.push(SingleQuery { raw, atom, negated, is_and });
     }
 
-    Ok(("", queries))
+    Ok(queries)
 }
 
 #[cfg(test)]
@@ -1063,14 +1039,14 @@ mod tests {
     fn parse_browserslist_query_empty() {
         let result = parse_browserslist_query("");
         assert!(result.is_ok());
-        assert!(result.unwrap().1.is_empty());
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]
     fn parse_browserslist_query_whitespace_only() {
         let result = parse_browserslist_query("   ");
         assert!(result.is_ok());
-        assert!(result.unwrap().1.is_empty());
+        assert!(result.unwrap().is_empty());
     }
 
     #[test]
@@ -1293,7 +1269,7 @@ mod tests {
     fn parse_browserslist_with_or() {
         let result = parse_browserslist_query("ie 10 or ie 11");
         assert!(result.is_ok());
-        let (_, queries) = result.unwrap();
+        let queries = result.unwrap();
         assert_eq!(queries.len(), 2);
         assert!(!queries[1].is_and);
     }
@@ -1302,7 +1278,7 @@ mod tests {
     fn parse_browserslist_with_and() {
         let result = parse_browserslist_query("ie >= 10 and ie <= 11");
         assert!(result.is_ok());
-        let (_, queries) = result.unwrap();
+        let queries = result.unwrap();
         assert_eq!(queries.len(), 2);
         assert!(queries[1].is_and);
     }
@@ -1311,7 +1287,7 @@ mod tests {
     fn parse_browserslist_with_not() {
         let result = parse_browserslist_query("ie >= 10, not ie 11");
         assert!(result.is_ok());
-        let (_, queries) = result.unwrap();
+        let queries = result.unwrap();
         assert_eq!(queries.len(), 2);
         assert!(queries[1].negated);
     }

--- a/src/queries/electron_unbounded_range.rs
+++ b/src/queries/electron_unbounded_range.rs
@@ -9,15 +9,7 @@ pub(super) fn electron_unbounded_range(comparator: Comparator, version: &str) ->
 
     let distribs = electron_versions()
         .iter()
-        .filter(|&&packed| {
-            let electron_version = unpack_version(packed);
-            match comparator {
-                Comparator::Greater => electron_version > version,
-                Comparator::Less => electron_version < version,
-                Comparator::GreaterOrEqual => electron_version >= version,
-                Comparator::LessOrEqual => electron_version <= version,
-            }
-        })
+        .filter(|&&packed| comparator.compare(unpack_version(packed), version))
         .map(|&packed| Distrib::new("chrome", unpack_chromium(packed)))
         .collect();
     Ok(distribs)

--- a/src/queries/last_n_node.rs
+++ b/src/queries/last_n_node.rs
@@ -1,8 +1,8 @@
 use super::{Distrib, QueryResult};
-use crate::data::node::NODE_VERSIONS;
+use crate::data::node::node_versions;
 
 pub(super) fn last_n_node(count: usize) -> QueryResult {
-    let distribs = NODE_VERSIONS()
+    let distribs = node_versions()
         .iter()
         .rev()
         .take(count)

--- a/src/queries/last_n_node_major.rs
+++ b/src/queries/last_n_node_major.rs
@@ -1,15 +1,15 @@
 use super::{Distrib, QueryResult};
-use crate::data::node::NODE_VERSIONS;
+use crate::data::node::node_versions;
 
 pub(super) fn last_n_node_major(count: usize) -> QueryResult {
     let mut vec =
-        NODE_VERSIONS().iter().rev().map(|(version, _)| version.major()).collect::<Vec<_>>();
+        node_versions().iter().rev().map(|(version, _)| version.major()).collect::<Vec<_>>();
     vec.dedup();
     // `count` can be 0 ("last 0 node major versions"); like browserslist-js, a minimum below
     // every version selects them all.
     let minimum = count.checked_sub(1).and_then(|n| vec.into_iter().nth(n)).unwrap_or_default();
 
-    let distribs = NODE_VERSIONS()
+    let distribs = node_versions()
         .iter()
         .filter(|(version, _)| version.major() >= minimum)
         .rev()

--- a/src/queries/maintained_node.rs
+++ b/src/queries/maintained_node.rs
@@ -1,5 +1,5 @@
 use super::{Distrib, QueryResult};
-use crate::data::node::{NODE_VERSIONS, release_schedule};
+use crate::data::node::{node_versions, release_schedule};
 use crate::date::now_julian_day;
 
 pub(super) fn maintained_node() -> QueryResult {
@@ -9,7 +9,7 @@ pub(super) fn maintained_node() -> QueryResult {
         .iter()
         .filter(|(_, start, end)| *start < now && now < *end)
         .filter_map(|(version, _, _)| {
-            NODE_VERSIONS().iter().rfind(|(v, _)| v.major() == version.major())
+            node_versions().iter().rfind(|(v, _)| v.major() == version.major())
         })
         .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();

--- a/src/queries/mod.rs
+++ b/src/queries/mod.rs
@@ -110,7 +110,7 @@ pub fn query(atom: QueryAtom, opts: &Opts) -> QueryResult {
         QueryAtom::Last { count, major, name: Some(name) }
             if name.eq_ignore_ascii_case("electron") =>
         {
-            let count = count as usize;
+            let count = usize::from(count);
             if major {
                 last_n_electron_major::last_n_electron_major(count)
             } else {
@@ -118,7 +118,7 @@ pub fn query(atom: QueryAtom, opts: &Opts) -> QueryResult {
             }
         }
         QueryAtom::Last { count, major, name: Some(name) } if name.eq_ignore_ascii_case("node") => {
-            let count = count as usize;
+            let count = usize::from(count);
             if major {
                 last_n_node_major::last_n_node_major(count)
             } else {
@@ -126,7 +126,7 @@ pub fn query(atom: QueryAtom, opts: &Opts) -> QueryResult {
             }
         }
         QueryAtom::Last { count, major, name: Some(name) } => {
-            let count = count as usize;
+            let count = usize::from(count);
             if major {
                 last_n_x_major_browsers::last_n_x_major_browsers(count, name, opts)
             } else {
@@ -134,7 +134,7 @@ pub fn query(atom: QueryAtom, opts: &Opts) -> QueryResult {
             }
         }
         QueryAtom::Last { count, major, name: None } => {
-            let count = count as usize;
+            let count = usize::from(count);
             if major {
                 last_n_major_browsers::last_n_major_browsers(count, opts)
             } else {
@@ -207,20 +207,18 @@ pub fn count_filter_versions(name: &str, mobile_to_desktop: bool, count: usize) 
         "android" => {
             if mobile_to_desktop {
                 return count;
-            } else {
-                let last_released = &caniuse::get_browser_stat("android", mobile_to_desktop)
-                    .unwrap()
-                    .1
-                    .version_list
-                    .iter()
-                    .filter(|version| version.release_date().is_some())
-                    .map(|version| version.version())
-                    .next_back()
-                    .unwrap()
-                    .parse::<f32>()
-                    .unwrap();
-                (last_released - caniuse::ANDROID_EVERGREEN_FIRST) as usize
             }
+            let last_released = caniuse::get_browser_stat("android", mobile_to_desktop)
+                .unwrap()
+                .1
+                .version_list
+                .iter()
+                .rfind(|version| version.release_date().is_some())
+                .unwrap()
+                .version()
+                .parse::<f32>()
+                .unwrap();
+            (last_released - caniuse::ANDROID_EVERGREEN_FIRST) as usize
         }
         "op_mob" => {
             let latest = caniuse::get_browser_stat("android", mobile_to_desktop)
@@ -249,7 +247,6 @@ pub fn find_minimum_major(stat: &caniuse::BrowserStat, count: usize) -> usize {
             if seen > count {
                 break;
             }
-            // SAFETY: major borrows from version which borrows from stat (lives long enough within this scope)
             last_major = Some(major);
         }
     }

--- a/src/queries/node_accurate.rs
+++ b/src/queries/node_accurate.rs
@@ -1,12 +1,10 @@
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, error::Error, opts::Opts};
+use crate::{data::node::node_versions, error::Error, opts::Opts};
 
 pub(super) fn node_accurate(version_str: &str, opts: &Opts) -> QueryResult {
-    for v in version_str.split('.') {
-        let is_valid = if v == "0" { true } else { !v.starts_with('0') };
-        if !is_valid {
-            return Err(Error::UnknownNodejsVersion(version_str.to_string()));
-        }
+    // Reject leading zeros (e.g. "08"), like the JavaScript implementation.
+    if version_str.split('.').any(|n| n != "0" && n.starts_with('0')) {
+        return Err(Error::UnknownNodejsVersion(version_str.to_string()));
     }
 
     let mut s = version_str.split('.');
@@ -14,22 +12,13 @@ pub(super) fn node_accurate(version_str: &str, opts: &Opts) -> QueryResult {
     let minor = s.next().map(|n| n.parse::<u16>().unwrap_or_default());
     let patch = s.next().map(|n| n.parse::<u16>().unwrap_or_default());
 
-    let distribs = NODE_VERSIONS()
+    let distribs = node_versions()
         .iter()
         .rev()
         .find(|(v, _)| {
-            if let Some(major) = major {
-                let major_eq = major == v.0;
-                if let Some(minor) = minor {
-                    let minor_eq = minor == v.1;
-                    if let Some(patch) = patch {
-                        return major_eq && minor_eq && patch == v.2;
-                    }
-                    return major_eq && minor_eq;
-                }
-                return major_eq;
-            }
-            false
+            major.is_some_and(|major| major == v.0)
+                && minor.is_none_or(|minor| minor == v.1)
+                && patch.is_none_or(|patch| patch == v.2)
         })
         .map(|(_, text)| vec![Distrib::new("node", text.as_ref())]);
     if opts.ignore_unknown_versions {

--- a/src/queries/node_bounded_range.rs
+++ b/src/queries/node_bounded_range.rs
@@ -1,10 +1,10 @@
 use std::cmp::Ordering;
 
 use super::{Distrib, QueryResult};
-use crate::data::node::NODE_VERSIONS;
+use crate::data::node::node_versions;
 
 pub(super) fn node_bounded_range(from: &str, to: &str) -> QueryResult {
-    let distribs = NODE_VERSIONS()
+    let distribs = node_versions()
         .iter()
         .filter(|(version, _)| {
             matches!(version.loose_compare(from), Ordering::Greater | Ordering::Equal)

--- a/src/queries/node_unbounded_range.rs
+++ b/src/queries/node_unbounded_range.rs
@@ -1,22 +1,14 @@
-use std::{cmp::Ordering, str::FromStr};
+use std::str::FromStr;
 
 use super::{Distrib, QueryResult};
-use crate::{data::node::NODE_VERSIONS, error::Error, parser::Comparator, semver::Version};
+use crate::{data::node::node_versions, error::Error, parser::Comparator, semver::Version};
 
 pub(super) fn node_unbounded_range(comparator: Comparator, version: &str) -> QueryResult {
     let version =
         Version::from_str(version).map_err(|_| Error::UnknownNodejsVersion(version.to_string()))?;
-    let distribs = NODE_VERSIONS()
+    let distribs = node_versions()
         .iter()
-        .filter(|(v, _)| {
-            let ord = v.cmp(&version);
-            match comparator {
-                Comparator::Greater => matches!(ord, Ordering::Greater),
-                Comparator::Less => matches!(ord, Ordering::Less),
-                Comparator::GreaterOrEqual => matches!(ord, Ordering::Greater | Ordering::Equal),
-                Comparator::LessOrEqual => matches!(ord, Ordering::Less | Ordering::Equal),
-            }
-        })
+        .filter(|(v, _)| comparator.compare(*v, version))
         .map(|(_, text)| Distrib::new("node", text.as_ref()))
         .collect();
     Ok(distribs)

--- a/src/queries/percentage.rs
+++ b/src/queries/percentage.rs
@@ -7,10 +7,7 @@ pub(super) fn percentage(comparator: Comparator, popularity: f32) -> QueryResult
         .flat_map(|(name, stat)| {
             stat.version_list
                 .iter()
-                .filter(|version| {
-                    let usage = version.global_usage();
-                    comparator.compare_f32(usage, popularity)
-                })
+                .filter(|version| comparator.compare(version.global_usage(), popularity))
                 .map(move |version| Distrib::new(name.as_ref(), version.version()))
         })
         .collect();

--- a/src/queries/percentage_by_region.rs
+++ b/src/queries/percentage_by_region.rs
@@ -12,7 +12,7 @@ pub(super) fn percentage_by_region(
     if let Some(region_data) = get_usage_by_region(&normalized_region) {
         let distribs = region_data
             .iter()
-            .filter(|(_, _, usage)| comparator.compare_f32(*usage, popularity))
+            .filter(|(_, _, usage)| comparator.compare(*usage, popularity))
             .map(|(name, version, _)| Distrib::new(name, version))
             .collect();
         Ok(distribs)

--- a/src/queries/since.rs
+++ b/src/queries/since.rs
@@ -16,9 +16,7 @@ pub(super) fn since(year: i32, month: u32, day: u32, opts: &Opts) -> QueryResult
         .flat_map(|(name, stat)| {
             stat.version_list
                 .iter()
-                .filter(
-                    |version| matches!(version.release_date(), Some(date) if date.get() >= time),
-                )
+                .filter(|version| version.release_date().is_some_and(|date| date.get() >= time))
                 .map(move |version| Distrib::new(name, version.version()))
         })
         .collect();

--- a/src/queries/years.rs
+++ b/src/queries/years.rs
@@ -21,9 +21,7 @@ pub(super) fn years(count: f64, opts: &Opts) -> QueryResult {
         .flat_map(|(name, stat)| {
             stat.version_list
                 .iter()
-                .filter(
-                    |version| matches!(version.release_date(), Some(date) if date.get() >= time),
-                )
+                .filter(|version| version.release_date().is_some_and(|date| date.get() >= time))
                 .map(move |version| Distrib::new(name, version.version()))
         })
         .collect();

--- a/src/semver.rs
+++ b/src/semver.rs
@@ -6,52 +6,35 @@ pub struct Version(pub u16, pub u16, pub u16);
 
 impl Version {
     #[inline]
-    pub fn major(&self) -> u16 {
+    pub const fn major(self) -> u16 {
         self.0
     }
 
     #[inline]
-    pub fn minor(&self) -> u16 {
+    pub const fn minor(self) -> u16 {
         self.1
     }
 
     #[inline]
-    pub fn patch(&self) -> u16 {
+    pub const fn patch(self) -> u16 {
         self.2
     }
 
     pub fn parse(s: &str) -> Result<Self, ParseIntError> {
         let mut segments = s.split('.');
-        let major = match segments.next() {
-            Some(n) => n.parse()?,
-            None => 0,
-        };
-        let minor = match segments.next() {
-            Some(n) => n.parse()?,
-            None => 0,
-        };
-        let patch = match segments.next() {
-            Some(n) => n.parse()?,
-            None => 0,
-        };
-        Ok(Self(major, minor, patch))
+        let mut segment = || segments.next().map_or(Ok(0), str::parse);
+        Ok(Self(segment()?, segment()?, segment()?))
     }
 
-    pub fn loose_compare(&self, b: &str) -> Ordering {
+    pub fn loose_compare(self, b: &str) -> Ordering {
         let mut b = b.split('.');
         let Some(first) = b.next() else {
             return Ordering::Equal;
         };
-        let first: u16 = first.parse().unwrap_or_default();
-        let x = self.0.cmp(&first);
-        if !x.is_eq() {
-            return x;
-        }
-        let Some(second) = b.next() else {
-            return Ordering::Equal;
-        };
-        let second: u16 = second.parse().unwrap_or_default();
-        self.1.cmp(&second)
+        self.0.cmp(&first.parse().unwrap_or_default()).then_with(|| match b.next() {
+            Some(second) => self.1.cmp(&second.parse().unwrap_or_default()),
+            None => Ordering::Equal,
+        })
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -29,10 +29,9 @@ pub fn run_compare(query: &str, opts: &Opts, cwd: Option<&Path>) {
     }
     let output = String::from_utf8(command.output().unwrap().stdout).unwrap();
     let expected = output
-        .trim()
-        .split('\n')
+        .lines()
         .filter(|line| !line.is_empty())
-        .map(|s| s.to_string())
+        .map(ToString::to_string)
         .collect::<HashSet<_>>();
 
     let actual =

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -43,14 +43,13 @@ fn run_compare(query: &str, opts: &Opts) {
     match (npm_success, rust_result) {
         (true, Ok(browsers)) => {
             let expected = npm_output
-                .trim()
-                .split('\n')
+                .lines()
                 .filter(|line| !line.is_empty())
-                .map(|s| s.to_string())
+                .map(ToString::to_string)
                 .collect::<HashSet<_>>();
             let actual = browsers.iter().map(ToString::to_string).collect::<HashSet<_>>();
             if expected != actual {
-                println!("Query: {:?}", query);
+                println!("Query: {query:?}");
                 println!(
                     "actual - expected: {:?}",
                     actual.difference(&expected).collect::<Vec<_>>()
@@ -67,14 +66,12 @@ fn run_compare(query: &str, opts: &Opts) {
         }
         (true, Err(e)) => {
             panic!(
-                "npm succeeded but Rust failed for query {:?}\nnpm output: {}\nRust error: {:?}",
-                query, npm_output, e
+                "npm succeeded but Rust failed for query {query:?}\nnpm output: {npm_output}\nRust error: {e:?}"
             );
         }
         (false, Ok(browsers)) => {
             panic!(
-                "Rust succeeded but npm failed for query {:?}\nnpm stderr: {}\nRust result: {:?}",
-                query, npm_stderr, browsers
+                "Rust succeeded but npm failed for query {query:?}\nnpm stderr: {npm_stderr}\nRust result: {browsers:?}"
             );
         }
     }
@@ -130,7 +127,7 @@ fn browser_with_alias_strategy() -> impl Strategy<Value = String> {
 fn version_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
         (1u32..100).prop_map(|v| v.to_string()),
-        (1u32..100, 0u32..10).prop_map(|(major, minor)| format!("{}.{}", major, minor)),
+        (1u32..100, 0u32..10).prop_map(|(major, minor)| format!("{major}.{minor}")),
     ]
 }
 
@@ -140,77 +137,76 @@ fn comparator_strategy() -> impl Strategy<Value = &'static str> {
 
 fn last_versions_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        (1u32..10).prop_map(|n| format!("last {} versions", n)),
+        (1u32..10).prop_map(|n| format!("last {n} versions")),
         (1u32..10, browser_with_alias_strategy())
-            .prop_map(|(n, browser)| format!("last {} {} versions", n, browser)),
-        (1u32..5).prop_map(|n| format!("last {} major versions", n)),
+            .prop_map(|(n, browser)| format!("last {n} {browser} versions")),
+        (1u32..5).prop_map(|n| format!("last {n} major versions")),
         (1u32..5, browser_with_alias_strategy())
-            .prop_map(|(n, browser)| format!("last {} {} major versions", n, browser)),
+            .prop_map(|(n, browser)| format!("last {n} {browser} major versions")),
     ]
 }
 
 fn browser_accurate_strategy() -> impl Strategy<Value = String> {
     (browser_with_alias_strategy(), version_strategy())
-        .prop_map(|(browser, version)| format!("{} {}", browser, version))
+        .prop_map(|(browser, version)| format!("{browser} {version}"))
 }
 
 fn browser_bounded_range_strategy() -> impl Strategy<Value = String> {
     (browser_with_alias_strategy(), version_strategy(), version_strategy())
-        .prop_map(|(browser, from, to)| format!("{} {} - {}", browser, from, to))
+        .prop_map(|(browser, from, to)| format!("{browser} {from} - {to}"))
 }
 
 fn browser_unbounded_range_strategy() -> impl Strategy<Value = String> {
     (browser_with_alias_strategy(), comparator_strategy(), version_strategy())
-        .prop_map(|(browser, cmp, version)| format!("{} {} {}", browser, cmp, version))
+        .prop_map(|(browser, cmp, version)| format!("{browser} {cmp} {version}"))
 }
 
 fn percentage_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        (comparator_strategy(), 0.1f64..10.0).prop_map(|(cmp, pct)| format!("{} {:.1}%", cmp, pct)),
+        (comparator_strategy(), 0.1f64..10.0).prop_map(|(cmp, pct)| format!("{cmp} {pct:.1}%")),
         (comparator_strategy(), 0.1f64..10.0, prop::sample::select(REGIONS.to_vec()))
-            .prop_map(|(cmp, pct, region)| format!("{} {:.1}% in {}", cmp, pct, region)),
+            .prop_map(|(cmp, pct, region)| format!("{cmp} {pct:.1}% in {region}")),
     ]
 }
 
 fn cover_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        (0.1f64..50.0).prop_map(|pct| format!("cover {:.1}%", pct)),
+        (0.1f64..50.0).prop_map(|pct| format!("cover {pct:.1}%")),
         (0.1f64..50.0, prop::sample::select(REGIONS.to_vec()))
-            .prop_map(|(pct, region)| format!("cover {:.1}% in {}", pct, region)),
+            .prop_map(|(pct, region)| format!("cover {pct:.1}% in {region}")),
     ]
 }
 
 fn since_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        (2010i32..2025).prop_map(|year| format!("since {}", year)),
-        (2010i32..2025, 1u32..13).prop_map(|(year, month)| format!("since {}-{:02}", year, month)),
+        (2010i32..2025).prop_map(|year| format!("since {year}")),
+        (2010i32..2025, 1u32..13).prop_map(|(year, month)| format!("since {year}-{month:02}")),
         (2010i32..2025, 1u32..13, 1u32..29)
-            .prop_map(|(year, month, day)| format!("since {}-{:02}-{:02}", year, month, day)),
+            .prop_map(|(year, month, day)| format!("since {year}-{month:02}-{day:02}")),
     ]
 }
 
 fn last_years_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        (1u32..10).prop_map(|n| format!("last {} years", n)),
-        (1u32..5, 0u32..10).prop_map(|(n, frac)| format!("last {}.{} years", n, frac)),
+        (1u32..10).prop_map(|n| format!("last {n} years")),
+        (1u32..5, 0u32..10).prop_map(|(n, frac)| format!("last {n}.{frac} years")),
     ]
 }
 
 fn supports_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("supports {}", f)),
-        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("fully supports {}", f)),
-        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("partially supports {}", f)),
+        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("supports {f}")),
+        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("fully supports {f}")),
+        prop::sample::select(FEATURES.to_vec()).prop_map(|f| format!("partially supports {f}")),
     ]
 }
 
 fn node_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
-        version_strategy().prop_map(|v| format!("node {}", v)),
-        (comparator_strategy(), version_strategy())
-            .prop_map(|(cmp, v)| format!("node {} {}", cmp, v)),
+        version_strategy().prop_map(|v| format!("node {v}")),
+        (comparator_strategy(), version_strategy()).prop_map(|(cmp, v)| format!("node {cmp} {v}")),
         (version_strategy(), version_strategy())
-            .prop_map(|(from, to)| format!("node {} - {}", from, to)),
+            .prop_map(|(from, to)| format!("node {from} - {to}")),
         Just("maintained node versions".to_string()),
         Just("current node".to_string()),
     ]
@@ -228,18 +224,18 @@ fn electron_strategy() -> impl Strategy<Value = String> {
         "10.1", "11.0", "12.0", "13.0", "14.0", "15.0",
     ];
     prop_oneof![
-        prop::sample::select(known_versions.clone()).prop_map(|v| format!("electron {}", v)),
+        prop::sample::select(known_versions.clone()).prop_map(|v| format!("electron {v}")),
         (comparator_strategy(), prop::sample::select(known_versions.clone()))
-            .prop_map(|(cmp, v)| format!("electron {} {}", cmp, v)),
+            .prop_map(|(cmp, v)| format!("electron {cmp} {v}")),
         (prop::sample::select(known_versions.clone()), prop::sample::select(known_versions))
-            .prop_map(|(from, to)| format!("electron {} - {}", from, to)),
+            .prop_map(|(from, to)| format!("electron {from} - {to}")),
     ]
 }
 
 fn unreleased_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
         Just("unreleased versions".to_string()),
-        browser_with_alias_strategy().prop_map(|b| format!("unreleased {} versions", b)),
+        browser_with_alias_strategy().prop_map(|b| format!("unreleased {b} versions")),
     ]
 }
 
@@ -303,18 +299,16 @@ fn single_query_strategy() -> impl Strategy<Value = String> {
 
 fn maybe_negated_query_strategy() -> impl Strategy<Value = String> {
     (any::<bool>(), single_query_strategy())
-        .prop_map(|(negated, query)| if negated { format!("not {}", query) } else { query })
+        .prop_map(|(negated, query)| if negated { format!("not {query}") } else { query })
 }
 
 fn composed_query_strategy() -> impl Strategy<Value = String> {
     prop_oneof![
         single_query_strategy(),
-        (single_query_strategy(), single_query_strategy())
-            .prop_map(|(a, b)| format!("{}, {}", a, b)),
+        (single_query_strategy(), single_query_strategy()).prop_map(|(a, b)| format!("{a}, {b}")),
         (single_query_strategy(), maybe_negated_query_strategy())
-            .prop_map(|(a, b)| format!("{} and {}", a, b)),
-        (single_query_strategy(), single_query_strategy())
-            .prop_map(|(a, b)| format!("{} or {}", a, b)),
+            .prop_map(|(a, b)| format!("{a} and {b}")),
+        (single_query_strategy(), single_query_strategy()).prop_map(|(a, b)| format!("{a} or {b}")),
     ]
 }
 


### PR DESCRIPTION
Idiomatic cleanup of the hand-written sources; no behavior changes. All query results remain byte-identical against the npm browserslist CLI (proptest + integration suites), and a bench smoke run shows no perf movement.

## API shape

- `parse_browserslist_query` returned `("", Vec<SingleQuery>)` — the first tuple element was always empty. It now returns just the `Vec`.
- `NODE_VERSIONS()` was a function named like a const behind `#[allow(non_snake_case)]` — renamed to `node_versions()`.
- `_resolve` renamed to `resolve_impl`; `resolve` uses an `if let [query] = queries` slice pattern instead of matching on `len()`.

## Deduplication

- `Comparator`/`SupportKind` derive `Copy`; `compare_f32` generalized to `compare<T: PartialOrd>`, deleting hand-rolled ordering matches in `node_unbounded_range` and `electron_unbounded_range`.
- Parser: three identical feature-name scan loops → `parse_feature_name`; `match_version_keyword`/`match_year_keyword` share `match_plural_keyword`; `parse_float`/`parse_double` share `scan_number`.
- `Version::parse` collapses three identical `match` blocks into one closure; `loose_compare` uses `Ordering::then_with`.

## Modern idioms and small fixes

- `matches!(x, Some(v) if …)` → `is_some_and`; nested if-let ladders in `node_accurate` → `is_some_and`/`is_none_or`; `map(..).unwrap_or(false)` → `is_ok_and`; `count as usize` → `usize::from`.
- `caniuse_browsers().get(&Cow::Borrowed("chrome"))` → `.get("chrome")`; `contains_key` no longer clones a `String` for the lookup.
- Fixed the `election_version` typo, removed a misleading `// SAFETY:` comment on safe code, replaced a map-accumulating `fold` with a plain loop, inlined `format!` args in tests.

Deliberately unchanged: the `Ok(...)`-wrapping query handlers (uniform `QueryResult` dispatch), `as` casts in the blob decoders (bounded by the generated data format), and `parse_u16`/`parse_u32` wrapping arithmetic (JS parity).