### PR TITLE
ci: enable Windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - os: windows-latest
+          - os: windows-latest
           - os: ubuntu-latest
           - os: macos-latest
     runs-on: ${{ matrix.os }}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use browserslist::{Opts, resolve};
 #[track_caller]
 pub fn run_compare(query: &str, opts: &Opts, cwd: Option<&Path>) {
     #[cfg(target_os = "windows")]
-    let bin = "browserslist.exe";
+    let bin = "browserslist.cmd";
     #[cfg(not(target_os = "windows"))]
     let bin = "browserslist";
     // Use absolute path without canonicalize() to avoid flaky failures on macOS

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -18,7 +18,7 @@ use proptest::prelude::*;
 #[track_caller]
 fn run_compare(query: &str, opts: &Opts) {
     #[cfg(target_os = "windows")]
-    let bin = "browserslist.exe";
+    let bin = "browserslist.cmd";
     #[cfg(not(target_os = "windows"))]
     let bin = "browserslist";
     // Use absolute path without canonicalize() to avoid flaky failures on macOS


### PR DESCRIPTION
Run the existing test job on `windows-latest` so platform-specific compilation regressions are caught in this repository.

Validated with `just ready`.