### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,3 +93,9 @@ lto = "fat"
 codegen-units = 1
 strip = "symbols" # Set to `false` for debug information
 debug = false # Set to `true` for debug information
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.